### PR TITLE
Minor Fixes and Upgrades

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: c
 compiler:
   - gcc
   - clang
-script: make
+script: bash test/test.sh

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ minimap2-lite:example.o libminimap2.a
 		$(CC) $(CFLAGS) $< -o $@ -L. -lminimap2 $(LIBS)
 
 libminimap2.a:$(OBJS)
-		$(AR) -csru $@ $(OBJS)
+		$(AR) -csr $@ $(OBJS)
 
 sdust:sdust.c kalloc.o kalloc.h kdq.h kvec.h kseq.h sdust.h
 		$(CC) -D_SDUST_MAIN $(CFLAGS) $< kalloc.o -o $@ -lz

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ sdust:sdust.c kalloc.o kalloc.h kdq.h kvec.h kseq.h sdust.h
 		$(CC) -D_SDUST_MAIN $(CFLAGS) $< kalloc.o -o $@ -lz
 
 clean:
-		rm -fr gmon.out *.o a.out $(PROG) $(PROG_EXTRA) *~ *.a *.dSYM session*
+		rm -fr gmon.out *.o a.out $(PROG) $(PROG_EXTRA) *~ *.a *.dSYM session* test_*
 
 depend:
 		(LC_ALL=C; export LC_ALL; makedepend -Y -- $(CFLAGS) $(CPPFLAGS) -- *.c)

--- a/align.c
+++ b/align.c
@@ -138,8 +138,10 @@ static void mm_align_pair(void *km, const mm_mapopt_t *opt, int qlen, const uint
 	if (mm_dbg_flag & MM_DBG_PRINT_ALN_SEQ) {
 		int i;
 		fprintf(stderr, "===> q=(%d,%d), e=(%d,%d), bw=%d, flag=%d, zdrop=%d <===\n", opt->q, opt->q2, opt->e, opt->e2, w, flag, opt->zdrop);
-		for (i = 0; i < tlen; ++i) fputc("ACGTN"[tseq[i]], stderr); fputc('\n', stderr);
-		for (i = 0; i < qlen; ++i) fputc("ACGTN"[qseq[i]], stderr); fputc('\n', stderr);
+		for (i = 0; i < tlen; ++i) fputc("ACGTN"[tseq[i]], stderr);
+		fputc('\n', stderr);
+		for (i = 0; i < qlen; ++i) fputc("ACGTN"[qseq[i]], stderr); 
+		fputc('\n', stderr);
 	}
 	if (opt->flag & MM_F_SPLICE)
 		ksw_exts2_sse(km, qlen, qseq, tlen, tseq, 5, mat, opt->q, opt->e, opt->q2, opt->noncan, opt->zdrop, flag, ez);

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# test build script and a few simple test cases 
+
+# to die on any error (non-zero return)
+set -e 
+
+# test build
+echo "0. Test build"
+make && echo "passed"
+
+# test cases removing files generated if test passes
+echo "1. Testing simple mapping"
+./minimap2 -ax map10k test/MT-human.fa test/MT-orang.fa > test_simple.sam && echo "passed" 
+rm test_simple.sam
+
+echo "2. Testing creating an index first and then mapping"
+./minimap2 -x map10k -d test_MT-human.mmi test/MT-human.fa
+./minimap2 -ax map10k test_MT-human.mmi test/MT-orang.fa > test_index.sam && echo "passed"
+rm test_MT-human.mmi test_index.sam


### PR DESCRIPTION
Main change is running the example test cases on travis via a small shell script.

Otherwise just removed an ignored flag in the makefile and moved `fputc` onto a new line to get rid of the compiler warning about misleading indentation.  