### PR TITLE
Fixed segfault caused when reading from index file

### DIFF
--- a/main.c
+++ b/main.c
@@ -240,6 +240,7 @@ int main(int argc, char *argv[])
 		mm_idx_t *mi;
 		if (fpr) {
 			mi = mm_idx_load(fpr);
+			if (mi == 0) break;
 			if (idx_par_set && mm_verbose >= 2 && (mi->k != k || mi->w != w || mi->is_hpc != is_hpc))
 				fprintf(stderr, "[WARNING] \033[1;31mIndexing parameters on the command line (-k/-w/-H) overridden by parameters in the prebuilt index.\033[0m\n");
 		} else {


### PR DESCRIPTION
Reading the target from an index file causes a segmentation fault. This happens when trying to compare kmer and minimizer sizes in the index with those set on the command line the second time through an infinite loop. The fix is just to check that mi exists before checking the kmers and minimizers are equal.