### PR TITLE
Added a "lastz"-like CIGAR format.

### DIFF
--- a/main.c
+++ b/main.c
@@ -23,35 +23,36 @@ void liftrlimit() {}
 #endif
 
 static struct option long_options[] = {
-	{ "bucket-bits",    required_argument, 0, 0 },
-	{ "mb-size",        required_argument, 0, 'K' },
-	{ "seed",           required_argument, 0, 0 },
-	{ "no-kalloc",      no_argument,       0, 0 },
-	{ "print-qname",    no_argument,       0, 0 },
-	{ "no-self",        no_argument,       0, 0 },
-	{ "print-seeds",    no_argument,       0, 0 },
-	{ "max-chain-skip", required_argument, 0, 0 },
-	{ "min-dp-len",     required_argument, 0, 0 },
-	{ "print-aln-seq",  no_argument,       0, 0 },
-	{ "splice",         no_argument,       0, 0 },
-	{ "cost-non-gt-ag", required_argument, 0, 'C' },
-	{ "no-long-join",   no_argument,       0, 0 },
-	{ "sr",             no_argument,       0, 0 },
-	{ "frag",           optional_argument, 0, 0 },
-	{ "secondary",      optional_argument, 0, 0 },
-	{ "cs",             optional_argument, 0, 0 },
-	{ "end-bonus",      required_argument, 0, 0 },
-	{ "no-pairing",     no_argument,       0, 0 },
-	{ "splice-flank",   optional_argument, 0, 0 },
-	{ "idx-no-seq",     no_argument,       0, 0 },
-	{ "help",           no_argument,       0, 'h' },
-	{ "max-intron-len", required_argument, 0, 'G' },
-	{ "version",        no_argument,       0, 'V' },
-	{ "min-count",      required_argument, 0, 'n' },
-	{ "min-chain-score",required_argument, 0, 'm' },
-	{ "mask-level",     required_argument, 0, 'M' },
-	{ "min-dp-score",   required_argument, 0, 's' },
-	{ "sam",            no_argument,       0, 'a' },
+	{ "bucket-bits",    required_argument, 0, 0 },  // 0
+	{ "mb-size",        required_argument, 0, 'K' },  // 1
+	{ "seed",           required_argument, 0, 0 },  // 2
+	{ "no-kalloc",      no_argument,       0, 0 }, // 3
+	{ "print-qname",    no_argument,       0, 0 }, // 4
+	{ "no-self",        no_argument,       0, 0 }, // 5
+	{ "print-seeds",    no_argument,       0, 0 }, // 6
+	{ "max-chain-skip", required_argument, 0, 0 }, // 7
+	{ "min-dp-len",     required_argument, 0, 0 }, // 8
+	{ "print-aln-seq",  no_argument,       0, 0 }, // 9
+	{ "splice",         no_argument,       0, 0 }, // 10
+	{ "cost-non-gt-ag", required_argument, 0, 'C' }, // 11
+	{ "no-long-join",   no_argument,       0, 0 }, // 12
+	{ "sr",             no_argument,       0, 0 },  // 13
+	{ "frag",           optional_argument, 0, 0 },  // 14
+	{ "secondary",      optional_argument, 0, 0 },  // 15
+	{ "cs",             optional_argument, 0, 0 }, // 16
+	{ "end-bonus",      required_argument, 0, 0 },  // 17
+	{ "no-pairing",     no_argument,       0, 0 },  // 18
+	{ "splice-flank",   optional_argument, 0, 0 },  // 19
+	{ "idx-no-seq",     no_argument,       0, 0 },  // 20
+	{ "help",           no_argument,       0, 'h' }, // 21
+	{ "max-intron-len", required_argument, 0, 'G' },  // 22 
+	{ "version",        no_argument,       0, 'V' }, // 23
+	{ "min-count",      required_argument, 0, 'n' },  // 24
+	{ "min-chain-score",required_argument, 0, 'm' },   // 25
+	{ "mask-level",     required_argument, 0, 'M' }, // 26
+	{ "min-dp-score",   required_argument, 0, 's' }, // 27
+	{ "sam",            no_argument,       0, 'a' }, // 28
+        { "lastz",    no_argument, 0, 0},  // 29 
 	{ 0, 0, 0, 0}
 };
 
@@ -140,6 +141,7 @@ int main(int argc, char *argv[])
 		else if (c == 0 && long_idx ==17) opt.end_bonus = atoi(optarg); // --end-bonus
 		else if (c == 0 && long_idx ==18) opt.flag |= MM_F_INDEPEND_SEG; // --no-pairing
 		else if (c == 0 && long_idx ==20) ipt.flag |= MM_I_NO_SEQ; // --idx-no-seq
+                else if (c == 0 && long_idx == 29) opt.flag |= MM_F_LASTZ | MM_F_CIGAR ;
 		else if (c == 0 && long_idx == 14) { // --frag
 			if (optarg == 0 || strcmp(optarg, "yes") == 0 || strcmp(optarg, "y") == 0)
 				opt.flag |= MM_F_FRAG_MODE;
@@ -242,6 +244,7 @@ int main(int argc, char *argv[])
 		fprintf(fp_help, "    -K NUM       minibatch size for mapping [500M]\n");
 //		fprintf(fp_help, "    -v INT       verbose level [%d]\n", mm_verbose);
 		fprintf(fp_help, "    --version    show version number\n");
+                fprintf(fp_help, "    --lastz      produce output similar to LASTZ --format=cigar output\n");
 		fprintf(fp_help, "  Preset:\n");
 		fprintf(fp_help, "    -x STR       preset (always applied before other options) []\n");
 		fprintf(fp_help, "                 map-pb: -Hk19 (PacBio vs reference mapping)\n");
@@ -268,13 +271,16 @@ int main(int argc, char *argv[])
 	}
 	if (opt.best_n == 0 && (opt.flag&MM_F_CIGAR) && mm_verbose >= 2)
 		fprintf(stderr, "[WARNING]\033[1;31m `-N 0' reduces alignment accuracy. Please use --secondary=no to suppress secondary alignments.\033[0m\n");
+        // Start mapping, I think
 	while ((mi = mm_idx_reader_read(idx_rdr, n_threads)) != 0) {
+                // No sequences, exit
 		if ((opt.flag & MM_F_CIGAR) && (mi->flag & MM_I_NO_SEQ)) {
 			fprintf(stderr, "[ERROR] the prebuilt index doesn't contain sequences.\n");
 			mm_idx_destroy(mi);
 			mm_idx_reader_close(idx_rdr);
 			return 1;
 		}
+                // Write SAM Header
 		if ((opt.flag & MM_F_OUT_SAM) && idx_rdr->n_parts == 1) {
 			if (mm_idx_reader_eof(idx_rdr)) {
 				mm_write_sam_hdr(mi, rg, MM_VERSION, argc, argv);
@@ -284,17 +290,21 @@ int main(int argc, char *argv[])
 					fprintf(stderr, "[WARNING]\033[1;31m For a multi-part index, no @SQ lines will be outputted.\033[0m\n");
 			}
 		}
+                // Finished creating the index
 		if (mm_verbose >= 3)
 			fprintf(stderr, "[M::%s::%.3f*%.2f] loaded/built the index for %d target sequence(s)\n",
 					__func__, realtime() - mm_realtime0, cputime() / (realtime() - mm_realtime0), mi->n_seq);
 		if (argc != optind + 1) mm_mapopt_update(&opt, mi);
+                // Print out the statistics about the index
 		if (mm_verbose >= 3) mm_idx_stat(mi);
+                // Start mapping
 		if (!(opt.flag & MM_F_FRAG_MODE)) {
 			for (i = optind + 1; i < argc; ++i)
 				mm_map_file(mi, argv[i], &opt, n_threads);
 		} else {
 			mm_map_file_frag(mi, argc - (optind + 1), (const char**)&argv[optind + 1], &opt, n_threads);
 		}
+                // Unload the index from memory
 		mm_idx_destroy(mi);
 	}
 	mm_idx_reader_close(idx_rdr);

--- a/map.c
+++ b/map.c
@@ -485,7 +485,10 @@ static void *worker_pipeline(void *shared, int step, void *in)
 						continue;
 					if (p->opt->flag & MM_F_OUT_SAM)
 						mm_write_sam2(&p->str, mi, t, i - seg_st, j, s->n_seg[k], &s->n_reg[seg_st], (const mm_reg1_t*const*)&s->reg[seg_st], km, p->opt->flag);
-					else
+					else if (p->opt->flag & MM_F_LASTZ)
+                                          mm_write_lastz(&p->str, mi, t, r, km, p->opt->flag);
+                                        else
+
 						mm_write_paf(&p->str, mi, t, r, km, p->opt->flag);
 					puts(p->str.s);
 				}

--- a/minimap.h
+++ b/minimap.h
@@ -25,6 +25,7 @@
 #define MM_F_INDEPEND_SEG  0x20000
 #define MM_F_SPLICE_FLANK  0x40000
 #define MM_F_SOFTCLIP      0x80000
+#define MM_F_LASTZ         0x100000
 
 #define MM_I_HPC          0x1
 #define MM_I_NO_SEQ       0x2

--- a/mmpriv.h
+++ b/mmpriv.h
@@ -56,6 +56,7 @@ void mm_sketch(void *km, const char *str, int len, int w, int k, uint32_t rid, i
 
 void mm_write_sam_hdr(const mm_idx_t *mi, const char *rg, const char *ver, int argc, char *argv[]);
 void mm_write_paf(kstring_t *s, const mm_idx_t *mi, const mm_bseq1_t *t, const mm_reg1_t *r, void *km, int opt_flag);
+void mm_write_lastz(kstring_t *s, const mm_idx_t *mi, const mm_bseq1_t *t, const mm_reg1_t *r, void *km, int opt_flag);
 void mm_write_sam(kstring_t *s, const mm_idx_t *mi, const mm_bseq1_t *t, const mm_reg1_t *r, int n_regs, const mm_reg1_t *regs);
 void mm_write_sam2(kstring_t *s, const mm_idx_t *mi, const mm_bseq1_t *t, int seg_idx, int reg_idx, int n_seg, const int *n_regs, const mm_reg1_t *const* regs, void *km, int opt_flag);
 


### PR DESCRIPTION
I added a "--lastz" switch for the command line interface, which produces an output following the format of LASTZ "--format=cigar" option, see here: http://www.bx.psu.edu/miller_lab/dist/README.lastz-1.02.00/README.lastz-1.02.00a.html#fmt_cigar.

This should allow minimap2 to be compatible with Cactus.