### PR TITLE
Check for whether output is correctly written

### DIFF
--- a/format.c
+++ b/format.c
@@ -112,8 +112,9 @@ err_set_rg:
 	free(rg_line);
 }
 
-void mm_write_sam_hdr(const mm_idx_t *idx, const char *rg, const char *ver, int argc, char *argv[])
+int mm_write_sam_hdr(const mm_idx_t *idx, const char *rg, const char *ver, int argc, char *argv[])
 {
+	int err;
 	kstring_t str = {0,0,0};
 	if (idx) {
 		uint32_t i;
@@ -130,8 +131,9 @@ void mm_write_sam_hdr(const mm_idx_t *idx, const char *rg, const char *ver, int 
 			mm_sprintf_lite(&str, " %s", argv[i]);
 	}
 	mm_sprintf_lite(&str, "\n");
-	fputs(str.s, stdout);
+	err = fputs(str.s, stdout);
 	free(str.s);
+	return err;
 }
 
 static void write_cs(void *km, kstring_t *s, const mm_idx_t *mi, const mm_bseq1_t *t, const mm_reg1_t *r, int no_iden)

--- a/main.c
+++ b/main.c
@@ -309,12 +309,17 @@ int main(int argc, char *argv[])
 			return 1;
 		}
 		if ((opt.flag & MM_F_OUT_SAM) && idx_rdr->n_parts == 1) {
+			int err;
 			if (mm_idx_reader_eof(idx_rdr)) {
-				mm_write_sam_hdr(mi, rg, MM_VERSION, argc, argv);
+				err = mm_write_sam_hdr(mi, rg, MM_VERSION, argc, argv);
 			} else {
-				mm_write_sam_hdr(0, rg, MM_VERSION, argc, argv);
+				err = mm_write_sam_hdr(0, rg, MM_VERSION, argc, argv);
 				if (mm_verbose >= 2)
 					fprintf(stderr, "[WARNING]\033[1;31m For a multi-part index, no @SQ lines will be outputted.\033[0m\n");
+			}
+			if (err == EOF) {
+				fprintf(stderr, "[ERROR] error writing output header\n");
+				return 1;
 			}
 		}
 		if (mm_verbose >= 3)
@@ -337,5 +342,11 @@ int main(int argc, char *argv[])
 	for (i = 0; i < argc; ++i)
 		fprintf(stderr, " %s", argv[i]);
 	fprintf(stderr, "\n[M::%s] Real time: %.3f sec; CPU: %.3f sec\n", __func__, realtime() - mm_realtime0, cputime());
+
+	int err = fflush(stdout);
+	if (err == EOF) {
+		fprintf(stderr, "[ERROR]: Could not flush output\n");
+		return 1;
+	}
 	return 0;
 }

--- a/map.c
+++ b/map.c
@@ -478,6 +478,7 @@ static void *worker_pipeline(void *shared, int step, void *in)
 		if ((p->opt->flag & MM_F_OUT_CS) && !(mm_dbg_flag & MM_DBG_NO_KALLOC)) km = km_init();
 		for (k = 0; k < s->n_frag; ++k) {
 			int seg_st = s->seg_off[k], seg_en = s->seg_off[k] + s->n_seg[k];
+			int err;
 			for (i = seg_st; i < seg_en; ++i) {
 				mm_bseq1_t *t = &s->seq[i];
 				for (j = 0; j < s->n_reg[i]; ++j) {
@@ -489,11 +490,13 @@ static void *worker_pipeline(void *shared, int step, void *in)
 						mm_write_sam2(&p->str, mi, t, i - seg_st, j, s->n_seg[k], &s->n_reg[seg_st], (const mm_reg1_t*const*)&s->reg[seg_st], km, p->opt->flag);
 					else
 						mm_write_paf(&p->str, mi, t, r, km, p->opt->flag);
-					puts(p->str.s);
+					err = puts(p->str.s);
+					if (err == EOF) exit(1);
 				}
 				if (s->n_reg[i] == 0 && (p->opt->flag & MM_F_OUT_SAM)) {
 					mm_write_sam2(&p->str, mi, t, i - seg_st, -1, s->n_seg[k], &s->n_reg[seg_st], (const mm_reg1_t*const*)&s->reg[seg_st], km, p->opt->flag);
-					puts(p->str.s);
+					err = puts(p->str.s);
+					if (err == EOF) exit(1);
 				}
 			}
 			for (i = seg_st; i < seg_en; ++i) {

--- a/mmpriv.h
+++ b/mmpriv.h
@@ -56,7 +56,7 @@ uint32_t ks_ksmall_uint32_t(size_t n, uint32_t arr[], size_t kk);
 
 void mm_sketch(void *km, const char *str, int len, int w, int k, uint32_t rid, int is_hpc, mm128_v *p);
 
-void mm_write_sam_hdr(const mm_idx_t *mi, const char *rg, const char *ver, int argc, char *argv[]);
+int mm_write_sam_hdr(const mm_idx_t *mi, const char *rg, const char *ver, int argc, char *argv[]);
 void mm_write_paf(kstring_t *s, const mm_idx_t *mi, const mm_bseq1_t *t, const mm_reg1_t *r, void *km, int opt_flag);
 void mm_write_sam(kstring_t *s, const mm_idx_t *mi, const mm_bseq1_t *t, const mm_reg1_t *r, int n_regs, const mm_reg1_t *regs);
 void mm_write_sam2(kstring_t *s, const mm_idx_t *mi, const mm_bseq1_t *t, int seg_idx, int reg_idx, int n_seg, const int *n_regs, const mm_reg1_t *const* regs, void *km, int opt_flag);


### PR DESCRIPTION
If `puts()` returns an error (e.g., writing to a full disk), then
immediately `exit(1)`. Also, flush the output at the end and check if
that operation was successful before exiting with a zero error code.

fixes #103 

Calling `exit(1)` from within a pthread is a bit heavy handed, but it's allowed by the pthread docs and works as expected (stops all threads and exits with the given error code).