### PR TITLE
Expose index i/o functions in public API

### DIFF
--- a/index.c
+++ b/index.c
@@ -420,8 +420,7 @@ void mm_idx_dump(FILE *fp, const mm_idx_t *mi)
 	fwrite(MM_IDX_MAGIC, 1, 4, fp);
 	fwrite(x, 4, 5, fp);
 	for (i = 0; i < mi->n_seq; ++i) {
-		uint8_t l;
-		l = strlen(mi->seq[i].name);
+		uint8_t l = mi->seq[i].name ? strlen(mi->seq[i].name) : 0;
 		fwrite(&l, 1, 1, fp);
 		fwrite(mi->seq[i].name, 1, l, fp);
 		fwrite(&mi->seq[i].len, 4, 1, fp);

--- a/index.c
+++ b/index.c
@@ -420,9 +420,14 @@ void mm_idx_dump(FILE *fp, const mm_idx_t *mi)
 	fwrite(MM_IDX_MAGIC, 1, 4, fp);
 	fwrite(x, 4, 5, fp);
 	for (i = 0; i < mi->n_seq; ++i) {
-		uint8_t l = mi->seq[i].name ? strlen(mi->seq[i].name) : 0;
-		fwrite(&l, 1, 1, fp);
-		fwrite(mi->seq[i].name, 1, l, fp);
+		if (mi->seq[i].name) {
+			uint8_t l = strlen(mi->seq[i].name);
+			fwrite(&l, 1, 1, fp);
+			fwrite(mi->seq[i].name, 1, l, fp);
+		} else {
+			uint8_t l = 0;
+			fwrite(&l, 1, 1, fp);
+		}
 		fwrite(&mi->seq[i].len, 4, 1, fp);
 		sum_len += mi->seq[i].len;
 	}
@@ -465,9 +470,11 @@ mm_idx_t *mm_idx_load(FILE *fp)
 		uint8_t l;
 		mm_idx_seq_t *s = &mi->seq[i];
 		fread(&l, 1, 1, fp);
-		s->name = (char*)kmalloc(mi->km, l + 1);
-		fread(s->name, 1, l, fp);
-		s->name[l] = 0;
+		if (l) {
+			s->name = (char*)kmalloc(mi->km, l + 1);
+			fread(s->name, 1, l, fp);
+			s->name[l] = 0;
+		}
 		fread(&s->len, 4, 1, fp);
 		s->offset = sum_len;
 		sum_len += s->len;

--- a/minimap.h
+++ b/minimap.h
@@ -220,6 +220,33 @@ void mm_idx_reader_close(mm_idx_reader_t *r);
 int mm_idx_reader_eof(const mm_idx_reader_t *r);
 
 /**
+ * Check whether the file contains a minimap2 index
+ *
+ * @param fn         index file name
+ * @return 1 if file can be opened and is a minimap2 index; 0 otherwise
+ */
+int64_t mm_idx_is_idx(const char *fn);
+
+/**
+ * Load an index
+ *
+ * Unlike mm_idx_reader_read this function specifically loads an existing
+ * index.
+ *
+ * @param fp         pointer to FILE object
+ * @return minimap2 index read from fp
+ */
+mm_idx_t *mm_idx_load(FILE *fp);
+
+/**
+ * Save an index
+ *
+ * @param fp         pointer to FILE object
+ * @param mi         minimap2 index
+ */
+void mm_idx_dump(FILE *fp, const mm_idx_t *mi);
+
+/**
  * Create an index from strings in memory
  *
  * @param w            minimizer window size


### PR DESCRIPTION
### Overview
- This PR puts signatures `mm_idx_load()`, `mm_idx_dump()` and `mm_idx_is_idx()` in `minimap.h`
- The first commit prevents calling `strlen()` on null reference names in `mm_idx_dump`.

### Rationale
I am using `minimap2` from C++ and need explicit API for storing and loading an already created index. 
 - Saving via the public API is currently impossible since `mm_idx_dump` is not exposed
 - For loading one can get by with `mm_idx_reader_read` but I do not see a downside of exposing `mm_idx_load` which indicates intent much more clearly.
 - The detection function `mm_idx_is_idx` is also nice to have for anyone using minimap2 as a library

### Testing
Saving and loading works as expected with small testing references as well as hg19