### PR TITLE
User specified splicing sites

### DIFF
--- a/align.c
+++ b/align.c
@@ -583,6 +583,7 @@ static void mm_align1(void *km, const mm_mapopt_t *opt, const mm_idx_t *mi, int 
 		if (splice_flag & MM_F_SPLICE_FOR) extra_flag |= rev? KSW_EZ_SPLICE_REV : KSW_EZ_SPLICE_FOR;
 		if (splice_flag & MM_F_SPLICE_REV) extra_flag |= rev? KSW_EZ_SPLICE_FOR : KSW_EZ_SPLICE_REV;
 		if (opt->flag & MM_F_SPLICE_FLANK) extra_flag |= KSW_EZ_SPLICE_FLANK;
+		if (mi->splices) extra_flag |= KSW_EZ_SPLICE_TAGS;
 	}
 
 	/* Look for the start and end of regions to perform DP. This sounds easy
@@ -666,7 +667,7 @@ static void mm_align1(void *km, const mm_mapopt_t *opt, const mm_idx_t *mi, int 
 
 	if (qs > 0 && rs > 0) { // left extension
 		qseq = &qseq0[rev][qs0];
-		mm_idx_getseq(mi, rid, rs0, rs, tseq);
+		mm_idx_getseq_splicetags(mi, rid, rs0, rs, tseq);
 		mm_seq_rev(qs - qs0, qseq);
 		mm_seq_rev(rs - rs0, tseq);
 		mm_align_pair(km, opt, qs - qs0, qseq, rs - rs0, tseq, mat, bw, opt->end_bonus, r->split_inv? opt->zdrop_inv : opt->zdrop, extra_flag|KSW_EZ_EXTZ_ONLY|KSW_EZ_RIGHT|KSW_EZ_REV_CIGAR, ez);
@@ -694,7 +695,7 @@ static void mm_align1(void *km, const mm_mapopt_t *opt, const mm_idx_t *mi, int 
 				bw1 = qe - qs > re - rs? qe - qs : re - rs;
 			// perform alignment
 			qseq = &qseq0[rev][qs];
-			mm_idx_getseq(mi, rid, rs, re, tseq);
+			mm_idx_getseq_splicetags(mi, rid, rs, re, tseq);
 			if (is_sr) { // perform ungapped alignment
 				assert(qe - qs == re - rs);
 				ksw_reset_extz(ez);
@@ -733,7 +734,7 @@ static void mm_align1(void *km, const mm_mapopt_t *opt, const mm_idx_t *mi, int 
 
 	if (!dropped && qe < qe0 && re < re0) { // right extension
 		qseq = &qseq0[rev][qe];
-		mm_idx_getseq(mi, rid, re, re0, tseq);
+		mm_idx_getseq_splicetags(mi, rid, re, re0, tseq);
 		mm_align_pair(km, opt, qe0 - qe, qseq, re0 - re, tseq, mat, bw, opt->end_bonus, opt->zdrop, extra_flag|KSW_EZ_EXTZ_ONLY, ez);
 		if (ez->n_cigar > 0) {
 			mm_append_cigar(r, ez->n_cigar, ez->cigar);

--- a/index.c
+++ b/index.c
@@ -65,7 +65,7 @@ void mm_idx_destroy(mm_idx_t *mi)
 		}
 	}
 	if (mi->splices) {
-		for(unsigned i = 0 ; i < mi->n_seq ; i++)
+		for(i = 0 ; i < mi->n_seq ; i++)
 			kv_destroy(((splice_v*) mi->splices)[i]);
 		kfree(mi->km, mi->splices);
 	}
@@ -174,8 +174,8 @@ int mm_idx_getseq_splicetags(const mm_idx_t *mi, uint32_t rid, uint32_t st, uint
 			else
 				low = mid + 1;
 		}
-		const splice_t* splices_end = &kv_A(splices, kv_size(splices));
-		for(const splice_t *p = &kv_A(splices, low) ; p < splices_end && SPLICE_POS(*p) < en; p++)
+		const splice_t *p, *splices_end = &kv_A(splices, kv_size(splices));
+		for(p = &kv_A(splices, low) ; p < splices_end && SPLICE_POS(*p) < en; p++)
 			seq[SPLICE_POS(*p) - st] |= 1 << (4 + SPLICE_IS_DONOR(*p));
 	}
 	return res;
@@ -622,6 +622,8 @@ int mm_idx_reader_eof(const mm_idx_reader_t *r) // TODO: in extremely rare cases
 }
 
 int mm_idx_splice_load(const char* fname, mm_idx_t* mi) {
+	unsigned i;
+
 	int type = 0; // 0=Unknown, 1=BED (introns), 2=TSV/CSV (unpaired sites)
 	const char* delim = " \t\r\n";
 	size_t fname_len = strlen(fname);
@@ -648,7 +650,7 @@ int mm_idx_splice_load(const char* fname, mm_idx_t* mi) {
 
 	mm_idx_index_name(mi);
 	splice_v* splice_vectors = (splice_v*) kmalloc(mi->km, sizeof(splice_v) * mi->n_seq);
-	for(unsigned i = 0 ; i < mi->n_seq ; i++)
+	for(i = 0 ; i < mi->n_seq ; i++)
 		kv_init(splice_vectors[i]);
 	mi->splices = splice_vectors;
 
@@ -713,7 +715,7 @@ int mm_idx_splice_load(const char* fname, mm_idx_t* mi) {
 	}
 
 	// Sort splicing coordinates for each reference sequence
-	for (unsigned i = 0 ; i < mi->n_seq ; i++) {
+	for (i = 0 ; i < mi->n_seq ; i++) {
 		splice_v splices = splice_vectors[i];
 		if (kv_size(splices))
 			radix_sort_splice(splices.a, splices.a + kv_size(splices));

--- a/ksw2.h
+++ b/ksw2.h
@@ -15,6 +15,7 @@
 #define KSW_EZ_SPLICE_FOR  0x100
 #define KSW_EZ_SPLICE_REV  0x200
 #define KSW_EZ_SPLICE_FLANK 0x400
+#define KSW_EZ_SPLICE_TAGS 0x800
 
 #ifdef __cplusplus
 extern "C" {

--- a/main.c
+++ b/main.c
@@ -228,11 +228,16 @@ int main(int argc, char *argv[])
 			else opt.mid_occ = (int)(x + .499);
 			if (*p == ',') opt.max_occ = (int)(strtod(p+1, &p) + .499);
 		} else if (c == 'u') {
-			if (*o.arg == 'b') opt.flag |= MM_F_SPLICE_FOR|MM_F_SPLICE_REV; // both strands
-			else if (*o.arg == 'f') opt.flag |= MM_F_SPLICE_FOR, opt.flag &= ~MM_F_SPLICE_REV; // match GT-AG
-			else if (*o.arg == 'r') opt.flag |= MM_F_SPLICE_REV, opt.flag &= ~MM_F_SPLICE_FOR; // match CT-AC (reverse complement of GT-AG)
-			else if (*o.arg == 'n') opt.flag &= ~(MM_F_SPLICE_FOR|MM_F_SPLICE_REV); // don't try to match the GT-AG signal
-			else {
+			if(o.arg[1] == '\0') {
+				if (*o.arg == 'b') opt.flag |= MM_F_SPLICE_FOR|MM_F_SPLICE_REV; // both strands
+				else if (*o.arg == 'f') opt.flag |= MM_F_SPLICE_FOR, opt.flag &= ~MM_F_SPLICE_REV; // match GT-AG
+				else if (*o.arg == 'r') opt.flag |= MM_F_SPLICE_REV, opt.flag &= ~MM_F_SPLICE_FOR; // match CT-AC (reverse complement of GT-AG)
+				else if (*o.arg == 'n') opt.flag &= ~(MM_F_SPLICE_FOR|MM_F_SPLICE_REV); // don't try to match the GT-AG signal
+				else {
+					fprintf(stderr, "[ERROR]\033[1;31m unrecognized cDNA direction\033[0m\n");
+					return 1;
+				}
+			} else {
 				splice_fname = o.arg;
 			}
 		} else if (c == 'z') {

--- a/minimap.h
+++ b/minimap.h
@@ -66,7 +66,7 @@ typedef struct {
 	mm_idx_seq_t *seq;         // sequence name, length and offset
 	uint32_t *S;               // 4-bit packed sequence
 	struct mm_idx_bucket_s *B; // index (hidden)
-	void *km, *h;
+	void *km, *h, *splices;
 } mm_idx_t;
 
 // minimap2 alignment
@@ -255,6 +255,15 @@ mm_idx_t *mm_idx_load(FILE *fp);
  * @param mi         minimap2 index
  */
 void mm_idx_dump(FILE *fp, const mm_idx_t *mi);
+
+/**
+ * Load splicing sites in the index
+ *
+ * @param fname      file name.
+ *
+ * @return 0 in case of success
+ */
+int mm_idx_splice_load(const char* fname, mm_idx_t *mi);
 
 /**
  * Create an index from strings in memory

--- a/minimap.h
+++ b/minimap.h
@@ -371,6 +371,7 @@ int mm_gen_MD(void *km, char **buf, int *max_len, const mm_idx_t *mi, const mm_r
 int mm_idx_index_name(mm_idx_t *mi);
 int mm_idx_name2id(const mm_idx_t *mi, const char *name);
 int mm_idx_getseq(const mm_idx_t *mi, uint32_t rid, uint32_t st, uint32_t en, uint8_t *seq);
+int mm_idx_getseq_splicetags(const mm_idx_t *mi, uint32_t rid, uint32_t st, uint32_t en, uint8_t *seq);
 
 // deprecated APIs for backward compatibility
 void mm_mapopt_init(mm_mapopt_t *opt);

--- a/options.c
+++ b/options.c
@@ -49,7 +49,7 @@ void mm_mapopt_init(mm_mapopt_t *opt)
 
 void mm_mapopt_update(mm_mapopt_t *opt, const mm_idx_t *mi)
 {
-	if ((opt->flag & MM_F_SPLICE_FOR) || (opt->flag & MM_F_SPLICE_REV))
+	if ((opt->flag & MM_F_SPLICE_FOR) || (opt->flag & MM_F_SPLICE_REV) || (mi->splices != 0))
 		opt->flag |= MM_F_SPLICE;
 	if (opt->mid_occ <= 0)
 		opt->mid_occ = mm_idx_cal_max_occ(mi, opt->mid_occ_frac);


### PR DESCRIPTION
This PR is mostly a feature request with a PoC implementation.

The bioinformatics team at the french sequencing center (Genoscope), working on MinION RNA-seq data, have expressed the need of specifying the splicing sites from an external source. In their _de novo_ workflow, they infer splicing sites by aligning cDNA SR on genomics contigs. They'd like to leverage this information for improving the alignment of cDNA and directRNA ONT reads on their assembly.
With high error rate, false positives of inferred splicing sites may cause exons to be misaligned, yielding the wrong isoform. There is also the rare cases of non canonical sites.

This PR loads splicing sites from a BED containing introns intervals or a TSV file listing unpaired splicing sites. The file is indicated on the command line with the '-u' flag. The BED format is compatible with files from [UCSC](http://genome.ucsc.edu/cgi-bin/hgTables). The TSV format is more proprietary and use the minimap2's internal coordinates (-1bp compared to BED's introns intervals). The TSV file has a column indicating wether the site is gap opening of closing.

Sites with contig name not in the reference index are discarded. The splicing coordinates are stored and sorted in one vector per reference sequence. The MSB bit of the coordinate is set if the site is gap opening (donor).
Multi-part indexes, are untested. In verbose mode it will complain about sites on contigs not found in the current part of the index.

Before each alignment, splicing sites for the region are retrieved and the corresponding nucleotides of the extracted reference sequence are [tagged in their high bits part](https://github.com/lh3/minimap2/commit/21c77566cc76dd4c4cc93a53fc782006a14fced5#diff-09a78bae6f5358adaa9e555aa8ddfa2dR161). This allows `ksw_exts2_sse` to remain unaware of sequence offsets. `ksw_exts2_sse` constructs it's `donor` and `acceptor` arrays by [reading the tags and then untag the reference](https://github.com/lh3/minimap2/commit/17664af29e92370bbf5cc52299f5629b320b87bd#diff-cbf4cf4330ddb7b157b0867a5ae4dc60R110).
**I'm not quite happy with all these contortions. There is a 5/10% loss in performance even without using specified sites.**
The fact that `ksw_exts2_sse` uses contiguous 16-bytes aligned pool for its arrays and is unaware of sequence offsets complicates the parameter passing without additional copying and allocating.

It also support an "hybrid mode" where splicing sites are both inferred and specified. Each specified site score +noncan/2, while canonical inferred sites score's remains 0 and non-canonical -noncan.
**I don't know if it's ok to use a positive score.** My reasoning is that we add information by using externally supplied sites. 

Initially in hybrid mode, the alignments with the sites inferred from the opposite strand of the transcript scored higher since they get more sites by adding the specified sites that may be on the opposite strand. The solution implemented is to remove the canonical sites on the opposite alignment strand from the list of specified sites.

I may add real world results when my colleagues are done with the evaluation.
Meanwhile, I'm open for comments and reviews.
Thanks !

Edit: [Here is a pile-up](https://i.imgur.com/rSgBVH7.png) of a small exon that got misaligned without knowledge of the gene model.
This is mouse brain sample direct RNA ONT read mapped on mm10. Top pile-up is generated with `-ax splice -u introns.bed` and bottom with `-ax splice` (original behaviour, the exon is missed). The region shown is chr9:37,544,827-37,546,222, an excerpt of the [neurogranin](https://www.ensembl.org/Mus_musculus/Gene/Summary?db=core;g=ENSMUSG00000053310;r=9:37544999-37546284;t=ENSMUST00000182070) gene.