### PR TITLE
Fixed mm_idx_is_idx to return the correct result on Windows.

### DIFF
--- a/index.c
+++ b/index.c
@@ -512,14 +512,19 @@ mm_idx_t *mm_idx_load(FILE *fp)
 int64_t mm_idx_is_idx(const char *fn)
 {
 	int fd, is_idx = 0;
-	off_t ret, off_end;
+	int64_t ret, off_end;
 	char magic[4];
 
 	if (strcmp(fn, "-") == 0) return 0; // read from pipe; not an index
 	fd = open(fn, O_RDONLY);
 	if (fd < 0) return -1; // error
+#ifdef WIN32
+	if ((off_end = _lseeki64(fd, 0, SEEK_END)) >= 4) {
+		_lseeki64(fd, 0, SEEK_SET);
+#else
 	if ((off_end = lseek(fd, 0, SEEK_END)) >= 4) {
 		lseek(fd, 0, SEEK_SET);
+#endif // WIN32
 		ret = read(fd, magic, 4);
 		if (ret == 4 && strncmp(magic, MM_IDX_MAGIC, 4) == 0)
 			is_idx = 1;


### PR DESCRIPTION
Hello, I have made a small change to the mm_idx_is_idx function so that it works correctly on Windows when using large index files.

When testing with index files in the order of gigabytes in size, we discovered that lseek does not return correct results for these very large files when compiled under MSVC.  Microsoft recommend _lseek and _lseeki64 instead:

https://docs.microsoft.com/en-gb/cpp/c-runtime-library/reference/lseek

Also "off_t" is defined as "long" in MSVC, which is only 4 bytes, so this also caused issues with indices over about 2GB.

Thanks :)