### PR TITLE
Add linux gcc-8 test case on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,18 @@ matrix:
       compiler: gcc
       script: make
     - language: c
+      compiler: gcc-8
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-8
+      env:
+        - CC=gcc-8
+        - AR=gcc-ar-8
+      script: make
+    - language: c
       compiler: clang
       script: make
     - language: python


### PR DESCRIPTION
This fixes https://github.com/lh3/minimap2/issues/234 .
