### PR TITLE
add option --sam-hit-only

### DIFF
--- a/main.c
+++ b/main.c
@@ -63,6 +63,7 @@ static ko_longopt_t long_options[] = {
 	{ "cap-sw-mem",     ko_required_argument, 337 },
 	{ "max-qlen",       ko_required_argument, 338 },
 	{ "max-chain-iter", ko_required_argument, 339 },
+    { "sam-hit-only",   ko_no_argument,       340 },
 	{ "help",           ko_no_argument,       'h' },
 	{ "max-intron-len", ko_required_argument, 'G' },
 	{ "version",        ko_no_argument,       'V' },
@@ -204,6 +205,7 @@ int main(int argc, char *argv[])
 		else if (c == 336) opt.flag |= MM_F_HARD_MLEVEL; // --hard-mask-level
 		else if (c == 337) opt.max_sw_mat = mm_parse_num(o.arg); // --cap-sw-mat
 		else if (c == 338) opt.max_qlen = mm_parse_num(o.arg); // --max-qlen
+        else if (c == 340) opt.flag |= MM_F_SAM_HIT_ONLY; // --sam-hit-only
 		else if (c == 314) { // --frag
 			yes_or_no(&opt, MM_F_FRAG_MODE, o.longidx, o.arg, 1);
 		} else if (c == 315) { // --secondary

--- a/map.c
+++ b/map.c
@@ -589,7 +589,7 @@ static void *worker_pipeline(void *shared, int step, void *in)
 							mm_write_paf3(&p->str, mi, t, r, km, p->opt->flag, s->rep_len[i]);
 						mm_err_puts(p->str.s);
 					}
-				} else if (p->opt->flag & (MM_F_OUT_SAM|MM_F_PAF_NO_HIT)) { // output an empty hit, if requested
+				} else if (p->opt->flag & ((MM_F_OUT_SAM&!MM_F_SAM_HIT_ONLY)|MM_F_PAF_NO_HIT)) { // output an empty hit, if requested
 					if (p->opt->flag & MM_F_OUT_SAM)
 						mm_write_sam3(&p->str, mi, t, i - seg_st, -1, s->n_seg[k], &s->n_reg[seg_st], (const mm_reg1_t*const*)&s->reg[seg_st], km, p->opt->flag, s->rep_len[i]);
 					else

--- a/minimap.h
+++ b/minimap.h
@@ -33,8 +33,9 @@
 #define MM_F_COPY_COMMENT  0x2000000
 #define MM_F_EQX           0x4000000 // use =/X instead of M
 #define MM_F_PAF_NO_HIT    0x8000000 // output unmapped reads to PAF
-#define MM_F_NO_END_FLT    0x10000000
-#define MM_F_HARD_MLEVEL   0x20000000
+#define MM_F_SAM_HIT_ONLY  0x10000000 // output only mapped reads to SAM
+#define MM_F_NO_END_FLT    0x20000000
+#define MM_F_HARD_MLEVEL   0x40000000
 
 #define MM_I_HPC          0x1
 #define MM_I_NO_SEQ       0x2

--- a/minimap2.1
+++ b/minimap2.1
@@ -478,6 +478,9 @@ In PAF, output unmapped queries; the strand and the reference name fields are
 set to `*'. Warning: some paftools.js commands may not work with such output
 for the moment.
 .TP
+.B --sam-hit-only
+In SAM, only output mapped queries.
+.TP
 .B --version
 Print version number to stdout
 .SS Preset options


### PR DESCRIPTION
Hi,

Many downstream tools expect only mapped queries in the SAM output (i.e. accepted hits file). By default, minimap2 output all queries. This request adds the option --sam-hit-only which allows the user to restrict the output to the mapped queries.

Please comment and I would be glad you could consider this request for merging into master. Thanks.

Charles