### PR TITLE
Add ppc64el build and login environment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ matrix:
     - language: c
       compiler: clang
       script: make
+    - name: ppc64el
+      language: c
+      script: make qemu arch ARCH=ppc64el
     - language: python
       python: "2.7"
       before_install: pip install cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ matrix:
     - language: c
       compiler: clang
       script: make
+    - name: armhf
+      language: c
+      script: make qemu arch ARCH=armhf ARGS="arm_neon=1"
+    - name: arm64
+      language: c
+      script: make qemu arch ARCH=arm64 ARGS="arm_neon=1 aarch64=1"
     - name: ppc64el
       language: c
       script: make qemu arch ARCH=ppc64el
@@ -21,3 +27,6 @@ matrix:
       python: "3.6"
       before_install: pip install cython
       script: python setup.py build_ext
+  allow_failures:
+    - name: ppc64el
+  fast_finish: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+ARG ARCH
+FROM multiarch/ubuntu-debootstrap:${ARCH}-bionic
+
+RUN uname -a
+RUN apt-get update -qq && \
+  apt-get install -yq --no-install-suggests --no-install-recommends \
+  build-essential \
+  gcc \
+  g++ \
+  make \
+  zlib1g-dev
+
+WORKDIR /build
+
+CMD ["bash"]

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ build-arch:
 		docker build --rm -t $(PROG):$(ARCH) --build-arg ARCH=$(ARCH) .
 
 arch: build-arch
-		docker run --rm -t -v $(CWD):/build $(PROG):$(ARCH) make
+		docker run --rm -t -v $(CWD):/build $(PROG):$(ARCH) make $(ARGS)
 
 login-arch: build-arch
 		docker run --rm -it -v $(CWD):/build $(PROG):$(ARCH)

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ OBJS=		kthread.o kalloc.o misc.o bseq.o sketch.o sdust.o options.o index.o chain
 PROG=		minimap2
 PROG_EXTRA=	sdust minimap2-lite
 LIBS=		-lm -lz -lpthread
+CWD =		$(shell pwd)
 
 ifeq ($(arm_neon),) # if arm_neon is not defined
 ifeq ($(sse2only),) # if sse2only is not defined
@@ -90,6 +91,18 @@ clean:
 
 depend:
 		(LC_ALL=C; export LC_ALL; makedepend -Y -- $(CFLAGS) $(CPPFLAGS) -- *.c)
+
+qemu:
+		docker run --rm --privileged multiarch/qemu-user-static:register --reset
+
+build-arch:
+		docker build --rm -t $(PROG):$(ARCH) --build-arg ARCH=$(ARCH) .
+
+arch: build-arch
+		docker run --rm -t -v $(CWD):/build $(PROG):$(ARCH) make
+
+login-arch: build-arch
+		docker run --rm -it -v $(CWD):/build $(PROG):$(ARCH)
 
 # DO NOT DELETE
 


### PR DESCRIPTION
This is related to https://github.com/lh3/minimap2/issues/393 and https://github.com/lh3/minimap2/issues/395 .
I would like to suggest to add ppc64el environment.

Here is the result on my repository's Travis CI.
https://travis-ci.org/junaruga/minimap2/builds/530465030

And how to check it on your side.

```
$ git clone -b feature/ppc64el https://github.com/junaruga/minimap2.git
$ cd minimap
```

Then to build it on ppc64el.

```
$ make qemu arch ARCH=ppc64el
...
cc -c -g -Wall -O2 -Wc++-compat  -msse2 -DHAVE_KALLOC  ksw2_ll_sse.c -o ksw2_ll_sse.o
cc: error: unrecognized command line option '-msse2'; did you mean '-misel'?
Makefile:52: recipe for target 'ksw2_ll_sse.o' failed
make: *** [ksw2_ll_sse.o] Error 1
gmake: *** [Makefile:102: arch] Error 2
```

Below command enables you to access to the ppc64el environment on your local PC. `make qemu` is required for the 1st time.
The files in the directory are shared between host OS (your x86_64 PC) and guest OS (ppc64el) by volume mount.

```
$ make qemu
$ make login-arch ARCH=ppc64el
root@5d042a21be7e:/build# uname -m
ppc64le
```

https://github.com/lh3/minimap2/issues/393#issuecomment-489720663
> See the limitation section of README. Minimap2 only works with x86 with SSE or arm with NEON. It doesn't work with the POWER SIMD instruction set.

You might use SIMDE (SIMD Everyware) library to do it.

Here is the case of `bowtie2` that I contributed.
https://github.com/BenLangmead/bowtie2/blob/master/sse_wrap.h#L30-L34

```
#ifdef __aarch64__
#include "simde/x86/sse2.h"
#else
#include <emmintrin.h>
#endif
```
