### PR TITLE
Add ARM 32/64 bit cases to CI.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -1,0 +1,12 @@
+# language: c does not work on aarch32.
+# https://github.com/Shippable/support/issues/4773
+language: none
+runtime:
+  - nodePool: shippable_shared_aarch32
+    build:
+      ci:
+        - make arm_neon=1
+  - nodePool: shippable_shared_aarch64
+    build:
+      ci:
+        - make arm_neon=1 aarch64=1


### PR DESCRIPTION
This PR is a suggestion to add current supported ARM 32/64 bit cases to Shippable CI that provides native ARM environments for free for open source project.

Here is a result of my repository.
https://app.shippable.com/github/junaruga/minimap2/runs/5/summary/console

While Travis CI only provides x86_64 and ppc64el environments, as far as I know, Shippable is the best native ARM CI, though it is still on the early stage.

Related to https://github.com/lh3/minimap2/pull/396 .