### PR TITLE
Add errno to file opening failure and I/O error messages

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
 #include "bseq.h"
 #include "minimap.h"
 #include "mmpriv.h"
@@ -172,7 +173,7 @@ int main(int argc, char *argv[])
 		else if (c == 'o') {
 			if (strcmp(o.arg, "-") != 0) {
 				if (freopen(o.arg, "wb", stdout) == NULL) {
-					fprintf(stderr, "[ERROR]\033[1;31m failed to write the output to file '%s'\033[0m\n", o.arg);
+					fprintf(stderr, "[ERROR]\033[1;31m failed to write the output to file '%s'\033[0m: %s\n", o.arg, strerror(errno));
 					exit(1);
 				}
 			}
@@ -337,7 +338,7 @@ int main(int argc, char *argv[])
 	}
 	idx_rdr = mm_idx_reader_open(argv[o.ind], &ipt, fnw);
 	if (idx_rdr == 0) {
-		fprintf(stderr, "[ERROR] failed to open file '%s'\n", argv[o.ind]);
+		fprintf(stderr, "[ERROR] failed to open file '%s': %s\n", argv[o.ind], strerror(errno));
 		return 1;
 	}
 	if (!idx_rdr->is_idx && fnw == 0 && argc - o.ind < 2) {
@@ -384,7 +385,7 @@ int main(int argc, char *argv[])
 		mm_split_merge(argc - (o.ind + 1), (const char**)&argv[o.ind + 1], &opt, n_parts);
 
 	if (fflush(stdout) == EOF) {
-		fprintf(stderr, "[ERROR] failed to write the results\n");
+		perror("[ERROR] failed to write the results");
 		exit(EXIT_FAILURE);
 	}
 

--- a/map.c
+++ b/map.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <errno.h>
 #include "kthread.h"
 #include "kvec.h"
 #include "kalloc.h"
@@ -622,7 +623,7 @@ static mm_bseq_file_t **open_bseqs(int n, const char **fn)
 	for (i = 0; i < n; ++i) {
 		if ((fp[i] = mm_bseq_open(fn[i])) == 0) {
 			if (mm_verbose >= 1)
-				fprintf(stderr, "ERROR: failed to open file '%s'\n", fn[i]);
+				fprintf(stderr, "ERROR: failed to open file '%s': %s\n", fn[i], strerror(errno));
 			for (j = 0; j < i; ++j)
 				mm_bseq_close(fp[j]);
 			free(fp);

--- a/misc.c
+++ b/misc.c
@@ -125,7 +125,7 @@ void mm_err_puts(const char *str)
 	int ret;
 	ret = puts(str);
 	if (ret == EOF) {
-		fprintf(stderr, "[ERROR] failed to write the results\n");
+		perror("[ERROR] failed to write the results");
 		exit(EXIT_FAILURE);
 	}
 }
@@ -135,7 +135,7 @@ void mm_err_fwrite(const void *p, size_t size, size_t nitems, FILE *fp)
 	int ret;
 	ret = fwrite(p, size, nitems, fp);
 	if (ret == EOF) {
-		fprintf(stderr, "[ERROR] failed to write data\n");
+		perror("[ERROR] failed to write data");
 		exit(EXIT_FAILURE);
 	}
 }
@@ -145,7 +145,7 @@ void mm_err_fread(void *p, size_t size, size_t nitems, FILE *fp)
 	int ret;
 	ret = fread(p, size, nitems, fp);
 	if (ret == EOF) {
-		fprintf(stderr, "[ERROR] failed to read data\n");
+		perror("[ERROR] failed to read data");
 		exit(EXIT_FAILURE);
 	}
 }

--- a/splitidx.c
+++ b/splitidx.c
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <errno.h>
 #include "mmpriv.h"
 
 FILE *mm_split_init(const char *prefix, const mm_idx_t *mi)
@@ -13,7 +14,7 @@ FILE *mm_split_init(const char *prefix, const mm_idx_t *mi)
 	sprintf(fn, "%s.%.4d.tmp", prefix, mi->index);
 	if ((fp = fopen(fn, "wb")) == NULL) {
 		if (mm_verbose >= 1)
-			fprintf(stderr, "[ERROR]\033[1;31m failed to write to temporary file '%s'\033[0m\n", fn);
+			fprintf(stderr, "[ERROR]\033[1;31m failed to write to temporary file '%s'\033[0m: %s\n", fn, strerror(errno));
 		exit(1);
 	}
 	mm_err_fwrite(&k, 4, 1, fp);
@@ -41,7 +42,7 @@ mm_idx_t *mm_split_merge_prep(const char *prefix, int n_splits, FILE **fp, uint3
 		sprintf(fn, "%s.%.4d.tmp", prefix, i);
 		if ((fp[i] = fopen(fn, "rb")) == 0) {
 			if (mm_verbose >= 1)
-				fprintf(stderr, "ERROR: failed to open temporary file '%s'\n", fn);
+				fprintf(stderr, "ERROR: failed to open temporary file '%s': %s\n", fn, strerror(errno));
 			for (j = 0; j < i; ++j)
 				fclose(fp[j]);
 			free(fn);


### PR DESCRIPTION
Add the underlying operating system error (usually "No such file" or "No space left on device" respectively, but highly informative when it is not) to these error messages.

Provides more information in cases like #452.