### PR TITLE
remove kstring_t definition in mmpriv

### DIFF
--- a/kseq.h
+++ b/kseq.h
@@ -89,7 +89,7 @@
 #ifndef KSTRING_T
 #define KSTRING_T kstring_t
 typedef struct __kstring_t {
-	unsigned l, m;
+	size_t l, m;
 	char *s;
 } kstring_t;
 #endif

--- a/mmpriv.h
+++ b/mmpriv.h
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include "minimap.h"
 #include "bseq.h"
+#include "kseq.h"
 
 #define MM_PARENT_UNSET   (-1)
 #define MM_PARENT_TMP_PRI (-2)
@@ -33,14 +34,6 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifndef KSTRING_T
-#define KSTRING_T kstring_t
-typedef struct __kstring_t {
-	unsigned l, m;
-	char *s;
-} kstring_t;
 #endif
 
 typedef struct {


### PR DESCRIPTION
In my previous PR, I missed a second definition of kstring_t in mmpriv.h. This PR removes this definition and includes `kseq.h` instead. Sorry for missing this originally.