### PR TITLE
travis: added arm64 test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ matrix:
     - language: c
       compiler: clang
       script: make
+    - arch: arm64
+      language: c
+      compiler: gcc
+      script: make arm_neon=1 aarch64=1
     - language: python
       python: "2.7"
       before_install: pip install cython


### PR DESCRIPTION
Travis CI has [multiple CPU feature](https://docs.travis-ci.com/user/multi-cpu-architectures/) now.
Here is [the CI result](https://travis-ci.org/github/junaruga/minimap2/builds/674330400) on my forked repository.
You can also use `arch: ppc64le` and `arch: s390x` syntax when you want to use it.

