### PR TITLE
sse2neon -> SIMDe and added non-SIMD version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/simde"]
+	path = lib/simde
+	url = https://github.com/nemequ/simde.git

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=		-g -Wall -O2 -Wc++-compat #-Wextra
+CFLAGS=		-g -Wall -O2 -Wc++-compat  #-Wextra
 CPPFLAGS=	-DHAVE_KALLOC
 INCLUDES=   -Ilib/simde/simde
 OBJS=		kthread.o kalloc.o misc.o bseq.o sketch.o sdust.o options.o index.o chain.o align.o hit.o map.o format.o pe.o esterr.o splitidx.o 
@@ -7,15 +7,15 @@ PROG_EXTRA=	sdust minimap2-lite
 LIBS=		-lm -lz -lpthread
 
 ifeq ($(no_simd),) # if no_simd is not defined
-	OBJS+=ksw2_ll_sse.o
 ifeq ($(arm_neon),) # if arm_neon is not defined
+	OBJS+=ksw2_ll_sse.o
 ifeq ($(sse2only),) # if sse2only is not defined
 	OBJS+=ksw2_extz2_sse41.o ksw2_extd2_sse41.o ksw2_exts2_sse41.o ksw2_extz2_sse2.o ksw2_extd2_sse2.o ksw2_exts2_sse2.o ksw2_dispatch.o
 else                # if sse2only is defined
 	OBJS+=ksw2_extz2_sse.o ksw2_extd2_sse.o ksw2_exts2_sse.o
 endif
 else				# if arm_neon is defined
-	OBJS+=ksw2_extz2_neon.o ksw2_extd2_neon.o ksw2_exts2_neon.o
+	OBJS+=ksw2_ll_sse.o ksw2_extz2_neon.o ksw2_extd2_neon.o ksw2_exts2_neon.o
 ifeq ($(aarch64),)	#if aarch64 is not defined
 	CFLAGS+=-D_FILE_OFFSET_BITS=64 -mfpu=neon -fsigned-char
 else				#if aarch64 is defined
@@ -60,10 +60,8 @@ sdust:sdust.c kalloc.o kalloc.h kdq.h kvec.h kseq.h ketopt.h sdust.h
 
 # SSE-specific targets on x86/x86_64
 
-ifeq ($(arm_neon),)   # if arm_neon is defined, compile this target with the default setting (i.e. no -msse2)
 ksw2_ll_sse.o:ksw2_ll_sse.c ksw2.h kalloc.h
 		$(CC) -c $(CFLAGS) -msse2 $(CPPFLAGS) $(INCLUDES) $< -o $@
-endif
 
 ksw2_extz2_sse41.o:ksw2_extz2_sse.c ksw2.h kalloc.h
 		$(CC) -c $(CFLAGS) -msse4.1 $(CPPFLAGS) -DKSW_CPU_DISPATCH $(INCLUDES) $< -o $@
@@ -87,6 +85,9 @@ ksw2_dispatch.o:ksw2_dispatch.c ksw2.h
 		$(CC) -c $(CFLAGS) -msse4.1 $(CPPFLAGS) -DKSW_CPU_DISPATCH $(INCLUDES) $< -o $@
 
 # NEON-specific targets on ARM
+ksw2_ll_neon.o:ksw2_ll_sse.c ksw2.h kalloc.h
+		$(CC) -c $(CFLAGS) -DSIMDE_ENABLE_NATIVE_ALIASES $(CPPFLAGS) $(INCLUDES) $< -o $@
+
 ksw2_extz2_neon.o:ksw2_extz2_sse.c ksw2.h kalloc.h
 		$(CC) -c $(CFLAGS) $(CPPFLAGS) -DKSW_SSE2_ONLY -D__SSE2__ -DSIMDE_ENABLE_NATIVE_ALIASES $(INCLUDES) $< -o $@
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ else                # if sse2only is defined
 	OBJS+=ksw2_extz2_sse.o ksw2_extd2_sse.o ksw2_exts2_sse.o
 endif
 else				# if arm_neon is defined
-	OBJS+=ksw2_ll_sse.o ksw2_extz2_neon.o ksw2_extd2_neon.o ksw2_exts2_neon.o
+	OBJS+=ksw2_ll_neon.o ksw2_extz2_neon.o ksw2_extd2_neon.o ksw2_exts2_neon.o
 ifeq ($(simde),)	# arm_neon without SIMDe -> use sse2neon
 	INCLUDES+=-Isse2neon
 endif

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ to disable SSE4 code, which will make minimap2 slightly slower.
 Minimap2 also works with ARM CPUs supporting the NEON instruction sets. To
 compile for 32 bit ARM architectures (such as ARMv7), use `make arm_neon=1`. To compile for for 64 bit ARM architectures (such as ARMv8), use `make arm_neon=1 aarch64=1`.
 
+Minimap2 can use [SIMD Everywhere (SIMDe)](https://github.com/nemequ/simde) library for porting implementation
+to the different SIMD instruction sets. To compile using SIMDe, use `make simde=1`. To compile for ARM CPUs, add `simde=1` to the commands given above.
+SIMDe also enables non-SIMD implementation using `make no_simd=1`.
+
 ### <a name="general"></a>General usage
 
 Without any options, minimap2 takes a reference database and a query sequence

--- a/ksw2_extd2_sse.c
+++ b/ksw2_extd2_sse.c
@@ -4,16 +4,22 @@
 #include "ksw2.h"
 
 #ifdef __SSE2__
-//#include <emmintrin.h>
-#include <x86/sse2.h>
+#ifndef USE_SIMDE
+#include <emmintrin.h>
+#else
+#include <simde/x86/sse2.h>
+#endif
 
 #ifdef KSW_SSE2_ONLY
 #undef __SSE4_1__
 #endif
 
 #ifdef __SSE4_1__
-//#include <smmintrin.h>
-#include <x86/sse4.1.h>
+#ifndef USE_SIMDE
+#include <smmintrin.h>
+#else
+#include <simde/x86/sse4.1.h>
+#endif
 #endif
 
 #ifdef KSW_CPU_DISPATCH

--- a/ksw2_extd2_sse.c
+++ b/ksw2_extd2_sse.c
@@ -4,10 +4,10 @@
 #include "ksw2.h"
 
 #ifdef __SSE2__
-#ifndef USE_SIMDE
-#include <emmintrin.h>
-#else
+#ifdef USE_SIMDE
 #include <simde/x86/sse2.h>
+#else
+#include <emmintrin.h>
 #endif
 
 #ifdef KSW_SSE2_ONLY
@@ -15,10 +15,10 @@
 #endif
 
 #ifdef __SSE4_1__
-#ifndef USE_SIMDE
-#include <smmintrin.h>
-#else
+#ifdef USE_SIMDE
 #include <simde/x86/sse4.1.h>
+#else
+#include <smmintrin.h>
 #endif
 #endif
 

--- a/ksw2_extd2_sse.c
+++ b/ksw2_extd2_sse.c
@@ -4,14 +4,16 @@
 #include "ksw2.h"
 
 #ifdef __SSE2__
-#include <emmintrin.h>
+//#include <emmintrin.h>
+#include <x86/sse2.h>
 
 #ifdef KSW_SSE2_ONLY
 #undef __SSE4_1__
 #endif
 
 #ifdef __SSE4_1__
-#include <smmintrin.h>
+//#include <smmintrin.h>
+#include <x86/sse4.1.h>
 #endif
 
 #ifdef KSW_CPU_DISPATCH

--- a/ksw2_exts2_sse.c
+++ b/ksw2_exts2_sse.c
@@ -4,20 +4,20 @@
 #include "ksw2.h"
 
 #ifdef __SSE2__
-#ifndef USE_SIMDE
-#include <emmintrin.h>
-#else
+#ifdef USE_SIMDE
 #include <simde/x86/sse2.h>
+#else
+#include <emmintrin.h>
 #endif
 #ifdef KSW_SSE2_ONLY
 #undef __SSE4_1__
 #endif
 
 #ifdef __SSE4_1__
-#ifndef USE_SIMDE
-#include <smmintrin.h>
-#else
+#ifdef USE_SIMDE
 #include <simde/x86/sse4.1.h>
+#else
+#include <smmintrin.h>
 #endif
 #endif
 

--- a/ksw2_exts2_sse.c
+++ b/ksw2_exts2_sse.c
@@ -4,14 +4,15 @@
 #include "ksw2.h"
 
 #ifdef __SSE2__
-#include <emmintrin.h>
-
+//#include <emmintrin.h>
+#include <x86/sse2.h>
 #ifdef KSW_SSE2_ONLY
 #undef __SSE4_1__
 #endif
 
 #ifdef __SSE4_1__
-#include <smmintrin.h>
+//#include <smmintrin.h>
+#include <x86/sse4.1.h>
 #endif
 
 #ifdef KSW_CPU_DISPATCH

--- a/ksw2_exts2_sse.c
+++ b/ksw2_exts2_sse.c
@@ -4,15 +4,21 @@
 #include "ksw2.h"
 
 #ifdef __SSE2__
-//#include <emmintrin.h>
-#include <x86/sse2.h>
+#ifndef USE_SIMDE
+#include <emmintrin.h>
+#else
+#include <simde/x86/sse2.h>
+#endif
 #ifdef KSW_SSE2_ONLY
 #undef __SSE4_1__
 #endif
 
 #ifdef __SSE4_1__
-//#include <smmintrin.h>
-#include <x86/sse4.1.h>
+#ifndef USE_SIMDE
+#include <smmintrin.h>
+#else
+#include <simde/x86/sse4.1.h>
+#endif
 #endif
 
 #ifdef KSW_CPU_DISPATCH

--- a/ksw2_extz2_sse.c
+++ b/ksw2_extz2_sse.c
@@ -3,10 +3,10 @@
 #include "ksw2.h"
 
 #ifdef __SSE2__
-#ifndef USE_SIMDE
-#include <emmintrin.h>
-#else
+#ifdef USE_SIMDE
 #include <simde/x86/sse2.h>
+#else
+#include <emmintrin.h>
 #endif
 
 #ifdef KSW_SSE2_ONLY
@@ -14,10 +14,10 @@
 #endif
 
 #ifdef __SSE4_1__
-#ifndef USE_SIMDE
-#include <smmintrin.h>
-#else
+#ifdef USE_SIMDE
 #include <simde/x86/sse4.1.h>
+#else
+#include <smmintrin.h>
 #endif
 #endif
 

--- a/ksw2_extz2_sse.c
+++ b/ksw2_extz2_sse.c
@@ -3,14 +3,16 @@
 #include "ksw2.h"
 
 #ifdef __SSE2__
-#include <emmintrin.h>
+//#include <emmintrin.h>
+#include <x86/sse2.h>
 
 #ifdef KSW_SSE2_ONLY
 #undef __SSE4_1__
 #endif
 
 #ifdef __SSE4_1__
-#include <smmintrin.h>
+//#include <smmintrin.h>
+#include <x86/sse4.1.h>
 #endif
 
 #ifdef KSW_CPU_DISPATCH

--- a/ksw2_extz2_sse.c
+++ b/ksw2_extz2_sse.c
@@ -3,16 +3,22 @@
 #include "ksw2.h"
 
 #ifdef __SSE2__
-//#include <emmintrin.h>
-#include <x86/sse2.h>
+#ifndef USE_SIMDE
+#include <emmintrin.h>
+#else
+#include <simde/x86/sse2.h>
+#endif
 
 #ifdef KSW_SSE2_ONLY
 #undef __SSE4_1__
 #endif
 
 #ifdef __SSE4_1__
-//#include <smmintrin.h>
-#include <x86/sse4.1.h>
+#ifndef USE_SIMDE
+#include <smmintrin.h>
+#else
+#include <simde/x86/sse4.1.h>
+#endif
 #endif
 
 #ifdef KSW_CPU_DISPATCH

--- a/ksw2_ll_sse.c
+++ b/ksw2_ll_sse.c
@@ -1,9 +1,13 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-//#include <emmintrin.h>
-#include <x86/sse2.h>
 #include "ksw2.h"
+
+#ifndef USE_SIMDE
+#include <emmintrin.h>
+#else
+#include <simde/x86/sse2.h>
+#endif
 
 #ifdef __GNUC__
 #define LIKELY(x) __builtin_expect((x),1)

--- a/ksw2_ll_sse.c
+++ b/ksw2_ll_sse.c
@@ -1,7 +1,8 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include <emmintrin.h>
+//#include <emmintrin.h>
+#include <x86/sse2.h>
 #include "ksw2.h"
 
 #ifdef __GNUC__

--- a/ksw2_ll_sse.c
+++ b/ksw2_ll_sse.c
@@ -3,10 +3,10 @@
 #include <string.h>
 #include "ksw2.h"
 
-#ifndef USE_SIMDE
-#include <emmintrin.h>
-#else
+#ifdef USE_SIMDE
 #include <simde/x86/sse2.h>
+#else
+#include <emmintrin.h>
 #endif
 
 #ifdef __GNUC__


### PR DESCRIPTION
Substituted sse2neon by SIMDe library to convert SSE2 to ARM Neon.
Added option to build non-SIMD version of minimap2 using SIMDe.

SIMDe is added as a git submodule.