### PR TITLE
travis: added ppc64le and s390x test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ matrix:
       language: c
       compiler: gcc
       script: make arm_neon=1 aarch64=1
+    - arch: arm64
+      language: c
+      compiler: gcc
+      script: make -f Makefile.simde arm_neon=1 aarch64=1
     - language: python
       python: "2.7"
       before_install: pip install cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,14 @@ matrix:
       language: c
       compiler: gcc
       script: make -f Makefile.simde arm_neon=1 aarch64=1
+    - arch: ppc64le
+      language: c
+      compiler: gcc
+      script: make -f Makefile.simde
+    - arch: s390x
+      language: c
+      compiler: gcc
+      script: make -f Makefile.simde
     - language: python
       python: "2.7"
       before_install: pip install cython

--- a/Makefile.simde
+++ b/Makefile.simde
@@ -6,6 +6,7 @@ OBJS=		kthread.o kalloc.o misc.o bseq.o sketch.o sdust.o options.o index.o chain
 PROG=		minimap2
 PROG_EXTRA=	sdust minimap2-lite
 LIBS=		-lm -lz -lpthread
+SSE4=
 
 
 ifneq ($(arm_neon),) # if arm_neon is defined
@@ -14,6 +15,10 @@ ifeq ($(aarch64),)   #if aarch64 is not defined
 else                 #if aarch64 is defined
 	CFLAGS+=-D_FILE_OFFSET_BITS=64 -fsigned-char
 endif
+endif
+
+ifeq ($(sse2only),) #if sse2only is not defined
+        SSE4+=-D__SSE4_1__
 endif
 
 ifneq ($(asan),)
@@ -49,16 +54,16 @@ sdust:sdust.c kalloc.o kalloc.h kdq.h kvec.h kseq.h ketopt.h sdust.h
 		$(CC) -D_SDUST_MAIN $(CFLAGS) $< kalloc.o -o $@ -lz
 
 ksw2_ll_simde.o:ksw2_ll_sse.c ksw2.h kalloc.h
-		$(CC) -c $(CFLAGS) -msse2 $(CPPFLAGS) $(INCLUDES) $< -o $@
+		$(CC) -c $(CFLAGS) -D__SSE2__ $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 ksw2_extz2_simde.o:ksw2_extz2_sse.c ksw2.h kalloc.h
-		$(CC) -c $(CFLAGS) -msse4.1 $(CPPFLAGS) $(INCLUDES) $< -o $@
+		$(CC) -c $(CFLAGS) -D__SSE2__ $(SSE4) $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 ksw2_extd2_simde.o:ksw2_extd2_sse.c ksw2.h kalloc.h
-		$(CC) -c $(CFLAGS) -msse4.1 $(CPPFLAGS) $(INCLUDES) $< -o $@
+		$(CC) -c $(CFLAGS) -D__SSE2__ $(SSE4) $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 ksw2_exts2_simde.o:ksw2_exts2_sse.c ksw2.h kalloc.h
-		$(CC) -c $(CFLAGS) -msse4.1 $(CPPFLAGS) $(INCLUDES) $< -o $@
+		$(CC) -c $(CFLAGS) -D__SSE2__ $(SSE4) $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 # other non-file targets
 


### PR DESCRIPTION
This PR is to add ppc64le and s390x test to Travis CI. There are 2 commits. 1st commit is to rebase the commits used in https://github.com/lh3/minimap2/pull/604 .
 
Travis is ok on my forked repository [here](https://travis-ci.org/github/junaruga/minimap2/builds/688097109).

It seems Debian minimap2 deb package already has [both ppc64le and 390x builds](https://packages.debian.org/sid/minimap2) using simde in their [Makefile](https://salsa.debian.org/med-team/minimap2/-/blob/master/debian/rules#L7). I am not sure if we should set `-fopenmp-simd  -DSIMDE_ENABLE_OPENMP` flag in `Makefile.simde` like Debian's one is doing.

