### PR TITLE
split-index mapping in separate processes

### DIFF
--- a/main.c
+++ b/main.c
@@ -118,7 +118,6 @@ static inline void yes_or_no(mm_mapopt_t *opt, int flag, int long_idx, const cha
 static int split_merge_cmd(int argc, char *argv[], mm_mapopt_t* opt) {
 	int n_query_fn = 0, n_intermediate_fn = 0;
 	char **query_fn = argv, **intermediate_fn = 0;
-	fprintf(stderr, "%d %s\n", argc, argv[0]);
 	for (; n_query_fn < argc && strcmp(argv[n_query_fn], "."); ++n_query_fn);
 	if (n_query_fn < argc - 1) {
 		n_intermediate_fn = argc - n_query_fn - 1;
@@ -379,7 +378,7 @@ int main(int argc, char *argv[])
 	}
 
 	if (split_merge) {
-		return split_merge_cmd(argc - (o.ind + 1), &argv[o.ind + 1], &opt);
+		return split_merge_cmd(argc - o.ind, &argv[o.ind], &opt);
 	}
 	if (opt.split_map && opt.split_prefix) {
 		fprintf(stderr, "[ERROR] specify at most one of --split-prefix or --split-map\n");

--- a/main.c
+++ b/main.c
@@ -80,6 +80,8 @@ static ko_longopt_t long_options[] = {
 	{ "mask-level",     ko_required_argument, 'M' },
 	{ "min-dp-score",   ko_required_argument, 's' },
 	{ "sam",            ko_no_argument,       'a' },
+	{ "split-map",      ko_required_argument, 348 },
+	{ "split-merge",    ko_no_argument,       349 },
 	{ 0, 0, 0 }
 };
 
@@ -113,13 +115,29 @@ static inline void yes_or_no(mm_mapopt_t *opt, int flag, int long_idx, const cha
 	}
 }
 
+static int split_merge_cmd(int argc, char *argv[], mm_mapopt_t* opt) {
+	int n_query_fn = 0, n_intermediate_fn = 0;
+	char **query_fn = argv, **intermediate_fn = 0;
+	fprintf(stderr, "%d %s\n", argc, argv[0]);
+	for (; n_query_fn < argc && strcmp(argv[n_query_fn], "."); ++n_query_fn);
+	if (n_query_fn < argc - 1) {
+		n_intermediate_fn = argc - n_query_fn - 1;
+		intermediate_fn = &argv[n_query_fn+1];
+	}
+	if (!(n_query_fn && n_intermediate_fn)) {
+		fprintf(stderr, "[ERROR] with --split-merge, specify at least one query file and one --split-map intermediate file, separated by '.'\n");
+		return 1;
+	}
+	return mm_split_merge(n_query_fn, (const char**) query_fn, opt, n_intermediate_fn, (const char**) intermediate_fn);
+}
+
 int main(int argc, char *argv[])
 {
 	const char *opt_str = "2aSDw:k:K:t:r:f:Vv:g:G:I:d:XT:s:x:Hcp:M:n:z:A:B:O:E:m:N:Qu:R:hF:LC:yYPo:e:U:";
 	ketopt_t o = KETOPT_INIT;
 	mm_mapopt_t opt;
 	mm_idxopt_t ipt;
-	int i, c, n_threads = 3, n_parts, old_best_n = -1;
+	int i, c, n_threads = 3, n_parts, old_best_n = -1, split_merge = 0;
 	char *fnw = 0, *rg = 0, *junc_bed = 0, *s, *alt_list = 0;
 	FILE *fp_help = stderr;
 	mm_idx_reader_t *idx_rdr;
@@ -225,6 +243,8 @@ int main(int argc, char *argv[])
 		else if (c == 344) alt_list = o.arg; // --alt
 		else if (c == 345) opt.alt_drop = atof(o.arg); // --alt-drop
 		else if (c == 346) opt.mask_len = mm_parse_num(o.arg); // --mask-len
+		else if (c == 348) opt.split_map = o.arg; // --split-map
+		else if (c == 349) split_merge = 1; // --split-merge
 		else if (c == 330) {
 			fprintf(stderr, "[WARNING] \033[1;31m --lj-min-ratio has been deprecated.\033[0m\n");
 		} else if (c == 314) { // --frag
@@ -358,6 +378,14 @@ int main(int argc, char *argv[])
 		return fp_help == stdout? 0 : 1;
 	}
 
+	if (split_merge) {
+		return split_merge_cmd(argc - (o.ind + 1), &argv[o.ind + 1], &opt);
+	}
+	if (opt.split_map && opt.split_prefix) {
+		fprintf(stderr, "[ERROR] specify at most one of --split-prefix or --split-map\n");
+		return 1;
+	}
+
 	if ((opt.flag & MM_F_SR) && argc - o.ind > 3) {
 		fprintf(stderr, "[ERROR] incorrect input: in the sr mode, please specify no more than two query files.\n");
 		return 1;
@@ -382,7 +410,7 @@ int main(int argc, char *argv[])
 			mm_idx_reader_close(idx_rdr);
 			return 1;
 		}
-		if ((opt.flag & MM_F_OUT_SAM) && idx_rdr->n_parts == 1) {
+		if ((opt.flag & MM_F_OUT_SAM) && idx_rdr->n_parts == 1 && !opt.split_map) {
 			if (mm_idx_reader_eof(idx_rdr)) {
 				if (opt.split_prefix == 0)
 					ret = mm_write_sam_hdr(mi, rg, MM_VERSION, argc, argv);
@@ -398,6 +426,10 @@ int main(int argc, char *argv[])
 				mm_idx_reader_close(idx_rdr);
 				return 1;
 			}
+		}
+		if (opt.split_map && !mm_idx_reader_eof(idx_rdr)) {
+			fprintf(stderr, "[ERROR] use --split-prefix instead of --split-map for multi-part index file\n");
+			return 1;
 		}
 		if (mm_verbose >= 3)
 			fprintf(stderr, "[M::%s::%.3f*%.2f] loaded/built the index for %d target sequence(s)\n",
@@ -425,8 +457,10 @@ int main(int argc, char *argv[])
 	n_parts = idx_rdr->n_parts;
 	mm_idx_reader_close(idx_rdr);
 
-	if (opt.split_prefix)
-		mm_split_merge(argc - (o.ind + 1), (const char**)&argv[o.ind + 1], &opt, n_parts);
+	if (opt.split_prefix) {
+		assert(!opt.split_map);
+		mm_split_merge_tmp(argc - (o.ind + 1), (const char**) &argv[o.ind + 1], &opt, n_parts);
+	}
 
 	if (fflush(stdout) == EOF) {
 		perror("[ERROR] failed to write the results");

--- a/map.c
+++ b/map.c
@@ -470,6 +470,7 @@ static void merge_hits(step_t *s)
 			for (j = 0, l = 0; j < s->p->n_parts; ++j) {
 				for (t = 0; t < n_reg_part[j]; ++t, ++l) {
 					mm_reg1_t *r = &s->reg[k][l];
+					/* TODO: double-check all r->id match */
 					uint32_t capacity;
 					mm_err_fread(r, sizeof(mm_reg1_t), 1, fp[j]);
 					r->rid += s->p->rid_shift[j];
@@ -544,7 +545,8 @@ static void *worker_pipeline(void *shared, int step, void *in)
 			int seg_st = s->seg_off[k], seg_en = s->seg_off[k] + s->n_seg[k];
 			for (i = seg_st; i < seg_en; ++i) {
 				mm_bseq1_t *t = &s->seq[i];
-				if (p->opt->split_prefix && p->n_parts == 0) { // then write to temporary files
+				if (p->fp_split && p->n_parts == 0) { // then write to intermediate file
+					assert(p->opt->split_prefix || p->opt->split_map);
 					mm_err_fwrite(&s->n_reg[i],    sizeof(int), 1, p->fp_split);
 					mm_err_fwrite(&s->rep_len[i],  sizeof(int), 1, p->fp_split);
 					mm_err_fwrite(&s->frag_gap[i], sizeof(int), 1, p->fp_split);
@@ -624,7 +626,9 @@ int mm_map_file_frag(const mm_idx_t *idx, int n_segs, const char **fn, const mm_
 	pl.n_threads = n_threads > 1? n_threads : 1;
 	pl.mini_batch_size = opt->mini_batch_size;
 	if (opt->split_prefix)
-		pl.fp_split = mm_split_init(opt->split_prefix, idx);
+		pl.fp_split = mm_split_init_tmp(opt->split_prefix, idx);
+	else if (opt->split_map)
+		pl.fp_split = mm_split_init(opt->split_map, idx);
 	pl_threads = n_threads == 1? 1 : (opt->flag&MM_F_2_IO_THREADS)? 3 : 2;
 	kt_pipeline(pl_threads, worker_pipeline, &pl, 3);
 
@@ -641,7 +645,7 @@ int mm_map_file(const mm_idx_t *idx, const char *fn, const mm_mapopt_t *opt, int
 	return mm_map_file_frag(idx, 1, &fn, opt, n_threads);
 }
 
-int mm_split_merge(int n_segs, const char **fn, const mm_mapopt_t *opt, int n_split_idx)
+int mm_split_merge(int n_segs, const char **fn, const mm_mapopt_t *opt, int n_split_idx, const char **fn_intermediates)
 {
 	int i;
 	pipeline_t pl;
@@ -657,7 +661,7 @@ int mm_split_merge(int n_segs, const char **fn, const mm_mapopt_t *opt, int n_sp
 	pl.n_parts = n_split_idx;
 	pl.fp_parts  = CALLOC(FILE*, pl.n_parts);
 	pl.rid_shift = CALLOC(uint32_t, pl.n_parts);
-	pl.mi = mi = mm_split_merge_prep(opt->split_prefix, n_split_idx, pl.fp_parts, pl.rid_shift);
+	pl.mi = mi = mm_split_merge_prep(fn_intermediates, n_split_idx, pl.fp_parts, pl.rid_shift);
 	if (pl.mi == 0) {
 		free(pl.fp_parts);
 		free(pl.rid_shift);
@@ -682,6 +686,19 @@ int mm_split_merge(int n_segs, const char **fn, const mm_mapopt_t *opt, int n_sp
 	for (i = 0; i < pl.n_fp; ++i)
 		mm_bseq_close(pl.fp[i]);
 	free(pl.fp);
-	mm_split_rm_tmp(opt->split_prefix, n_split_idx);
 	return 0;
+}
+
+int mm_split_merge_tmp(int n_segs, const char **fn, const mm_mapopt_t *opt, int n_split_idx)
+{
+	char **fn_intermediates;
+	int ret, i;
+	fn_intermediates = mm_split_tmp_intermediates(opt->split_prefix, n_split_idx);
+	ret = mm_split_merge(n_segs, fn, opt, n_split_idx, (const char**) fn_intermediates);
+	for (i = 0; i < n_split_idx; ++i) {
+		remove(fn_intermediates[i]);
+		free(fn_intermediates[i]);
+	}
+	free(fn_intermediates);
+	return ret;
 }

--- a/minimap.h
+++ b/minimap.h
@@ -164,7 +164,8 @@ typedef struct {
 	int64_t mini_batch_size; // size of a batch of query bases to process in parallel
 	int64_t max_sw_mat;
 
-	const char *split_prefix;
+	const char *split_prefix;  // temp file prefix for mapping to split index (sequentially within one process)
+	const char *split_map;     // intermediate output file for mapping to one part of a split index
 } mm_mapopt_t;
 
 // index reader

--- a/mmpriv.h
+++ b/mmpriv.h
@@ -100,10 +100,13 @@ mm_seg_t *mm_seg_gen(void *km, uint32_t hash, int n_segs, const int *qlens, int 
 void mm_seg_free(void *km, int n_segs, mm_seg_t *segs);
 void mm_pair(void *km, int max_gap_ref, int dp_bonus, int sub_diff, int match_sc, const int *qlens, int *n_regs, mm_reg1_t **regs);
 
-FILE *mm_split_init(const char *prefix, const mm_idx_t *mi);
-mm_idx_t *mm_split_merge_prep(const char *prefix, int n_splits, FILE **fp, uint32_t *n_seq_part);
-int mm_split_merge(int n_segs, const char **fn, const mm_mapopt_t *opt, int n_split_idx);
-void mm_split_rm_tmp(const char *prefix, int n_splits);
+FILE *mm_split_init(const char *fn, const mm_idx_t *mi);
+FILE *mm_split_init_tmp(const char *prefix, const mm_idx_t *mi);
+mm_idx_t *mm_split_merge_prep(const char **intermediates, int n_splits, FILE **fp, uint32_t *n_seq_part);
+mm_idx_t *mm_split_merge_prep_tmp(const char *prefix, int n_splits, FILE **fp, uint32_t *n_seq_part);
+int mm_split_merge(int n_segs, const char **fn, const mm_mapopt_t *opt, int n_split_idx, const char **fn_intermediates);
+int mm_split_merge_tmp(int n_segs, const char **fn, const mm_mapopt_t *opt, int n_split_idx);
+char** mm_split_tmp_intermediates(const char *prefix, int n_splits);
 
 void mm_err_puts(const char *str);
 void mm_err_fwrite(const void *p, size_t size, size_t nitems, FILE *fp);


### PR DESCRIPTION
Hi @lh3 @hasindu2008

My colleagues @morsecodist @katrinakalantar @rzlim08 @tfrcarvalho and I hacked on the existing split-index mode so that we can map against each index part in a separate process (in general on a cluster of machines), then merge the intermediates in a final gather process. It's still a bit rough, but we'd appreciate any early feedback. This is for a metagenomics use case (e.g. mapping to all of nt) which I gather was [contemplated](https://www.nature.com/articles/s41598-019-40739-8#Sec10) in the design of the split index.

1. In this approach we first split the database FASTA file if needed, then build a minimap2 index file from each FASTA part separately.  As far as I could tell, the existing split index is just a blob concatenation of part indexes, so there's no meaningful difference with the same indexes in separate files -- did I miss something there?
2. Then we run e.g. `minimap2 --split-map part7.intermediate part7.idx reads_1.fq reads_2.fq` on each index part to generate the intermediate files.
3. Lastly `minimap2 --split-merge reads_1.fq reads_2.fq . part1.intermediate part2.intermediate ...` to merge the intermediates and generate PAF/SAM. This uses the existing merge subroutine unchanged, we're just restructuring the intermediate file I/O.

We have a [proof-of-concept workflow](https://github.com/mlin/minimap2-scatter) of this running (still to be tested at full scale).

The new approach coexists with the single-process `--split-prefix` mode -- the diff factors out its logic for formulating temporary filenames and deleting them afterwards.

One wart we have right now is that the `mm_mapopt_t` must get initialized consistently in all the invocations for steps 2 and 3. I think it's okay if the user takes care to set the same command-line options to them, but I'm not completely sure, given that step 3 never sees any part of the index -- advice appreciated.

Do you know any big pitfalls awaiting us in the merging subroutine if we try to use this on full-size metagenomics databases? (One we're anticipating is the mapQ being zeroed by all the redundancy in nt)