### PR TITLE
Cleanup memory when creating index

### DIFF
--- a/main.c
+++ b/main.c
@@ -406,7 +406,10 @@ int main(int argc, char *argv[])
 		if (mm_verbose >= 3) mm_idx_stat(mi);
 		if (junc_bed) mm_idx_bed_read(mi, junc_bed, 1);
 		if (alt_list) mm_idx_alt_read(mi, alt_list);
-		if (argc - (o.ind + 1) == 0) continue; // no query files
+		if (argc - (o.ind + 1) == 0) {
+			mm_idx_destroy(mi);
+			continue; // no query files
+		}
 		ret = 0;
 		if (!(opt.flag & MM_F_FRAG_MODE)) {
 			for (i = o.ind + 1; i < argc; ++i) {


### PR DESCRIPTION
Currently, even if the -I parameter is set, minimap2 seems to use up all the memory required to read in the entire genome file when building an index. I think that a memory leak was introduced from the `continue` statement at main.c:409 which prevented the `mm_idx_destroy` function from being called. 