### PR TITLE
Dockerfile for minimal container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Minimal Docker image for Minimap2 using Alpine base
+FROM alpine:3.13.5
+MAINTAINER Niema Moshiri <niemamoshiri@gmail.com>
+
+# install Minimap2
+RUN apk update && \
+    apk add bash gcc make musl-dev zlib-dev && \
+    wget -qO- "https://github.com/lh3/minimap2/archive/refs/tags/v2.22.tar.gz" | tar -zx && \
+    cd minimap2-* && \
+    make && \
+    chmod a+x minimap2 && \
+    mv minimap2 /usr/local/bin/minimap2 && \
+    cd .. && \
+    rm -rf minimap2-*


### PR DESCRIPTION
I've been maintaining minimal (<50 MB) Docker containers for Minimap2 here:

* **Dockerfile:** https://github.com/Niema-Docker/minimap2/blob/main/Dockerfile
* **Container:** https://hub.docker.com/r/niemasd/minimap2

It might be good to have a DockerHub repo linked directly to this GitHub repo so an "official" Docker container gets automatically generated when you make new releases.

This Dockerfile I've provided has the version number hardcoded, but if you wanted a Dockerfile that always pulls the most recent release, you could replace the following:

```bash
wget -qO- "https://github.com/lh3/minimap2/archive/refs/tags/v2.22.tar.gz" | tar -zx
```

with the following:

```bash
wget -qO- https://github.com/lh3/minimap2/archive/refs/tags/$(wget -qO- "https://api.github.com/repos/lh3/minimap2/releases/latest" | grep '"tag_name": "' | cut -d'"' -f4).tar.gz | tar -zx
```