### PR TITLE
Fix for compiling in windows using MSVC

### DIFF
--- a/kalloc.h
+++ b/kalloc.h
@@ -25,13 +25,13 @@ void km_stat(const void *_km, km_stat_t *s);
 }
 #endif
 
-#define KMALLOC(km, ptr, len) ((ptr) = (__typeof__(ptr))kmalloc((km), (len) * sizeof(*(ptr))))
-#define KCALLOC(km, ptr, len) ((ptr) = (__typeof__(ptr))kcalloc((km), (len), sizeof(*(ptr))))
-#define KREALLOC(km, ptr, len) ((ptr) = (__typeof__(ptr))krealloc((km), (ptr), (len) * sizeof(*(ptr))))
+#define KMALLOC(__type, km, ptr, len) ((ptr) = (__type*)kmalloc((km), (len) * sizeof(*(ptr))))
+#define KCALLOC(__type, km, ptr, len) ((ptr) = (__type*)kcalloc((km), (len), sizeof(*(ptr))))
+#define KREALLOC(__type, km, ptr, len) ((ptr) = (__type*)krealloc((km), (ptr), (len) * sizeof(*(ptr))))
 
-#define KEXPAND(km, a, m) do { \
+#define KEXPAND(__type, km, a, m) do { \
 		(m) = (m) >= 4? (m) + ((m)>>1) : 16; \
-		KREALLOC((km), (a), (m)); \
+		KREALLOC(__type, (km), (a), (m)); \
 	} while (0)
 
 #ifndef klib_unused
@@ -50,7 +50,7 @@ void km_stat(const void *_km, km_stat_t *s);
 	} kmp_##name##_t; \
 	SCOPE kmp_##name##_t *kmp_init_##name(void *km) { \
 		kmp_##name##_t *mp; \
-		KCALLOC(km, mp, 1); \
+		KCALLOC(kmp_##name##_t, km, mp, 1); \
 		mp->km = km; \
 		return mp; \
 	} \
@@ -66,7 +66,7 @@ void km_stat(const void *_km, km_stat_t *s);
 	} \
 	SCOPE void kmp_free_##name(kmp_##name##_t *mp, kmptype_t *p) { \
 		--mp->cnt; \
-		if (mp->n == mp->max) KEXPAND(mp->km, mp->buf, mp->max); \
+		if (mp->n == mp->max) KEXPAND(kmptype_t*, mp->km, mp->buf, mp->max); \
 		mp->buf[mp->n++] = p; \
 	}
 

--- a/lchain.c
+++ b/lchain.c
@@ -17,7 +17,7 @@ uint64_t *mg_chain_backtrack(void *km, int64_t n, const int32_t *f, const int64_
 	for (i = 0, n_z = 0; i < n; ++i) // precompute n_z
 		if (f[i] >= min_sc) ++n_z;
 	if (n_z == 0) return 0;
-	KMALLOC(km, z, n_z);
+	KMALLOC(mm128_t, km, z, n_z);
 	for (i = 0, k = 0; i < n; ++i) // populate z[]
 		if (f[i] >= min_sc) z[k].x = f[i], z[k++].y = i;
 	radix_sort_128x(z, z + n_z);
@@ -33,7 +33,7 @@ uint64_t *mg_chain_backtrack(void *km, int64_t n, const int32_t *f, const int64_
 			++n_u;
 		else n_v = n_v0;
 	}
-	KMALLOC(km, u, n_u);
+	KMALLOC(uint64_t, km, u, n_u);
 	memset(t, 0, n * 4);
 	for (k = n_z - 1, n_v = n_u = 0; k >= 0; --k) { // populate u[]
 		int64_t n_v0 = n_v;
@@ -58,7 +58,7 @@ static mm128_t *compact_a(void *km, int32_t n_u, uint64_t *u, int32_t n_v, int32
 	int64_t i, j, k;
 
 	// write the result to b[]
-	KMALLOC(km, b, n_v);
+	KMALLOC(mm128_t, km, b, n_v);
 	for (i = 0, k = 0; i < n_u; ++i) {
 		int32_t k0 = k, ni = (int32_t)u[i];
 		for (j = 0; j < ni; ++j)
@@ -67,13 +67,13 @@ static mm128_t *compact_a(void *km, int32_t n_u, uint64_t *u, int32_t n_v, int32
 	kfree(km, v);
 
 	// sort u[] and a[] by the target position, such that adjacent chains may be joined
-	KMALLOC(km, w, n_u);
+	KMALLOC(mm128_t, km, w, n_u);
 	for (i = k = 0; i < n_u; ++i) {
 		w[i].x = b[k].x, w[i].y = (uint64_t)k<<32|i;
 		k += (int32_t)u[i];
 	}
 	radix_sort_128x(w, w + n_u);
-	KMALLOC(km, u2, n_u);
+	KMALLOC(uint64_t, km, u2, n_u);
 	for (i = k = 0; i < n_u; ++i) {
 		int32_t j = (int32_t)w[i].y, n = (int32_t)u[j];
 		u2[i] = u[j];
@@ -135,10 +135,10 @@ mm128_t *mg_lchain_dp(int max_dist_x, int max_dist_y, int bw, int max_skip, int 
 	}
 	if (max_dist_x < bw) max_dist_x = bw;
 	if (max_dist_y < bw && !is_cdna) max_dist_y = bw;
-	KMALLOC(km, p, n);
-	KMALLOC(km, f, n);
-	KMALLOC(km, v, n);
-	KCALLOC(km, t, n);
+	KMALLOC(int64_t, km, p, n);
+	KMALLOC(int32_t, km, f, n);
+	KMALLOC(int32_t, km, v, n);
+	KCALLOC(int32_t, km, t, n);
 
 	// fill the score and backtrack arrays
 	for (i = 0, max_ii = -1; i < n; ++i) {
@@ -239,10 +239,10 @@ mm128_t *mg_lchain_rmq(int max_dist, int max_dist_inner, int bw, int max_chn_ski
 	}
 	if (max_dist < bw) max_dist = bw;
 	if (max_dist_inner <= 0 || max_dist_inner >= max_dist) max_dist_inner = 0;
-	KMALLOC(km, p, n);
-	KMALLOC(km, f, n);
-	KCALLOC(km, t, n);
-	KMALLOC(km, v, n);
+	KMALLOC(int64_t, km, p, n);
+	KMALLOC(int32_t, km, f, n);
+	KCALLOC(int32_t, km, t, n);
+	KMALLOC(int32_t, km, v, n);
 	mem_mp = km_init2(km, 0x10000);
 	mp = kmp_init_rmq(mem_mp);
 


### PR DESCRIPTION
__typeof__ macro is not available in MSVC and no alternative is available for C.
type must be explicitly passed to *ALLOC macros