### PR TITLE
Add functions to deallocate `mm_reg1_t`/`mm_extra_t`

### DIFF
--- a/example.c
+++ b/example.c
@@ -49,9 +49,9 @@ int main(int argc, char *argv[])
 				for (i = 0; i < r->p->n_cigar; ++i) // IMPORTANT: this gives the CIGAR in the aligned regions. NO soft/hard clippings!
 					printf("%d%c", r->p->cigar[i]>>4, MM_CIGAR_STR[r->p->cigar[i]&0xf]);
 				putchar('\n');
-				free(r->p);
+				mm_extra_destroy(r->p);
 			}
-			free(reg);
+			mm_reg1_destroy(reg);
 		}
 		mm_tbuf_destroy(tbuf);
 		mm_idx_destroy(mi);

--- a/map.c
+++ b/map.c
@@ -712,3 +712,13 @@ int mm_split_merge(int n_segs, const char **fn, const mm_mapopt_t *opt, int n_sp
 	mm_split_rm_tmp(opt->split_prefix, n_split_idx);
 	return 0;
 }
+
+void mm_reg1_destroy(mm_reg1_t *r)
+{
+	free(r);
+}
+
+void mm_extra_destroy(mm_extra_t *p)
+{
+	free(p);
+}

--- a/minimap.h
+++ b/minimap.h
@@ -317,6 +317,20 @@ void mm_idx_stat(const mm_idx_t *idx);
 void mm_idx_destroy(mm_idx_t *mi);
 
 /**
+ * Destroy/deallocate a region
+ *
+ * @param r          region
+ */
+void mm_reg1_destroy(mm_reg1_t *r);
+
+/**
+ * Destroy/deallocate alignment extra data
+ *
+ * @param p          extra data
+ */
+void mm_extra_destroy(mm_extra_t *p);
+
+/**
  * Initialize a thread-local buffer for mapping
  *
  * Each mapping thread requires a buffer specific to the thread (see mm_map()


### PR DESCRIPTION
Certain functions in minimap2 allocate `mm_reg1_t`/`mm_extra_t` objects (like `mm_map()`), which one can't safely deallocate across an FFI boundary (since there's no guarantee that the same allocator is used). These changes provide a way to deallocate these objects from another language safely.