### PR TITLE
Build mappy via Makefile and libminimap2.a

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython"]

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,35 @@
 try:
 	from setuptools import setup, Extension
+	from setuptools.command.build_ext import build_ext
 except ImportError:
 	from distutils.core import setup
 	from distutils.extension import Extension
+	from distutils.command.build_ext import build_ext
 
-import sys, platform
+import sys, platform, subprocess
 
-sys.path.append('python')
-
-extra_compile_args = ['-DHAVE_KALLOC']
-include_dirs = ["."]
-
-if platform.machine() in ["aarch64", "arm64"]:
-	include_dirs.append("sse2neon/")
-	extra_compile_args.extend(['-ftree-vectorize', '-DKSW_SSE2_ONLY', '-D__SSE2__'])
-else:
-	extra_compile_args.append('-msse4.1') # WARNING: ancient x86_64 CPUs don't have SSE4
 
 def readme():
 	with open('python/README.rst') as f:
 		return f.read()
+
+
+class LibMM2Build(build_ext):
+	# Uses Makefile to build library, avoids duplicating logic
+	# determining which objects to compile but does require
+	# end users to have Make (since precompiled wheels are not
+	# distributed on PyPI).
+	def run(self):
+		def compile_libminimap2(*args, **kwargs):
+			cmd = ['make', 'libminimap2.a'] + list(args)
+			subprocess.check_call(cmd)
+		if platform.machine() in ["aarch64", "arm64"]:
+			options = ["arm_neon=1", "aarch64=1"]
+		self.execute(
+			compile_libminimap2, options,
+			'Compiling libminimap2 using Makefile')
+		build_ext.run(self)
+
 
 setup(
 	name = 'mappy',
@@ -32,16 +42,15 @@ setup(
 	license = 'MIT',
 	keywords = 'sequence-alignment',
 	scripts = ['python/minimap2.py'],
-	ext_modules = [Extension('mappy',
-		sources = ['python/mappy.pyx', 'align.c', 'bseq.c', 'lchain.c', 'seed.c', 'format.c', 'hit.c', 'index.c', 'pe.c', 'options.c',
-				   'ksw2_extd2_sse.c', 'ksw2_exts2_sse.c', 'ksw2_extz2_sse.c', 'ksw2_ll_sse.c',
-				   'kalloc.c', 'kthread.c', 'map.c', 'misc.c', 'sdust.c', 'sketch.c', 'esterr.c', 'splitidx.c'],
-		depends = ['minimap.h', 'bseq.h', 'kalloc.h', 'kdq.h', 'khash.h', 'kseq.h', 'ksort.h',
-				   'ksw2.h', 'kthread.h', 'kvec.h', 'mmpriv.h', 'sdust.h',
-				   'python/cmappy.h', 'python/cmappy.pxd'],
-		extra_compile_args = extra_compile_args,
-		include_dirs = include_dirs,
-		libraries = ['z', 'm', 'pthread'])],
+	cmdclass = {'build_ext': LibMM2Build},
+	ext_modules = [
+		Extension(
+			'mappy',
+			sources = ['python/mappy.pyx'],
+			depends = ['python/cmappy.h', 'python/cmappy.pxd'],
+			include_dirs = ['.'],
+			extra_objects = ['libminimap2.a'],
+			libraries = ['z', 'm', 'pthread'])],
 	classifiers = [
 		'Development Status :: 5 - Production/Stable',
 		'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Resolves https://github.com/lh3/minimap2/issues/867.

`pip install mappy` current fails with compile errors around neon. I suspect at some point the install worked but the `setup.py` hasn't kept pace with the Makefile in terms of how things should be built on ARM.

This implements one method of ensuring mappy build is in sync with that defined in Makefile for minimap2. Alternatively the Makefile if statements need translating to the `setup.py`.