### PR TITLE
Enable compilation on aarch64 Linux

### DIFF
--- a/Makefile.simde
+++ b/Makefile.simde
@@ -8,12 +8,18 @@ PROG_EXTRA=	sdust minimap2-lite
 LIBS=		-lm -lz -lpthread
 
 
+
 ifneq ($(arm_neon),) # if arm_neon is defined
+	SSE2_CFLAG=  -D__SSE2__	
+	SSE4_1_CFLAG= $(SSE2_CFLAG) -D__SSE4_1__
 ifeq ($(aarch64),)   #if aarch64 is not defined
 	CFLAGS+=-D_FILE_OFFSET_BITS=64 -mfpu=neon -fsigned-char
 else                 #if aarch64 is defined
 	CFLAGS+=-D_FILE_OFFSET_BITS=64 -fsigned-char
 endif
+else
+	SSE2_CFLAG=	-msse2
+	SSE4_1_CFLAG=	-msse4.1
 endif
 
 ifneq ($(asan),)
@@ -49,16 +55,16 @@ sdust:sdust.c kalloc.o kalloc.h kdq.h kvec.h kseq.h ketopt.h sdust.h
 		$(CC) -D_SDUST_MAIN $(CFLAGS) $< kalloc.o -o $@ -lz
 
 ksw2_ll_simde.o:ksw2_ll_sse.c ksw2.h kalloc.h
-		$(CC) -c $(CFLAGS) -msse2 $(CPPFLAGS) $(INCLUDES) $< -o $@
+		$(CC) -c $(CFLAGS) $(SSE2_CFLAG) $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 ksw2_extz2_simde.o:ksw2_extz2_sse.c ksw2.h kalloc.h
-		$(CC) -c $(CFLAGS) -msse4.1 $(CPPFLAGS) $(INCLUDES) $< -o $@
+		$(CC) -c $(CFLAGS) $(SSE4_1_CFLAG) $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 ksw2_extd2_simde.o:ksw2_extd2_sse.c ksw2.h kalloc.h
-		$(CC) -c $(CFLAGS) -msse4.1 $(CPPFLAGS) $(INCLUDES) $< -o $@
+		$(CC) -c $(CFLAGS) $(SSE4_1_CFLAG) $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 ksw2_exts2_simde.o:ksw2_exts2_sse.c ksw2.h kalloc.h
-		$(CC) -c $(CFLAGS) -msse4.1 $(CPPFLAGS) $(INCLUDES) $< -o $@
+		$(CC) -c $(CFLAGS) $(SSE4_1_CFLAG) $(CPPFLAGS) $(INCLUDES) $< -o $@
 
 # other non-file targets
 


### PR DESCRIPTION
This patch changes Makefile.simde such that it compiles on aarch64 Linux using SIMDe.

GCC will error on aarch64 with the "-msse4.1" flag - so this is removed for aarch64.

However - it is still necessary to #define __SSE2__ and __SSE4.1__ on aarch64 so that the right blocks of code are seen by the compiler that use SIMDe.