### PR TITLE
mappy check index flags before mapping

### DIFF
--- a/python/mappy.pyx
+++ b/python/mappy.pyx
@@ -172,6 +172,7 @@ cdef class Aligner:
 		cdef cmappy.mm_mapopt_t map_opt
 
 		if self._idx == NULL: return
+		if ((self.map_opt.flag & 4) and (self._idx.flag & 2)): return
 		map_opt = self.map_opt
 		if max_frag_len is not None: map_opt.max_frag_len = max_frag_len
 		if extra_flags is not None: map_opt.flag |= extra_flags
@@ -217,6 +218,7 @@ cdef class Aligner:
 		cdef int l
 		cdef char *s
 		if self._idx == NULL: return
+		if ((self.map_opt.flag & 4) and (self._idx.flag & 2)): return
 		s = cmappy.mappy_fetch_seq(self._idx, name.encode(), start, end, &l)
 		if l == 0: return None
 		r = s[:l] if isinstance(s, str) else s[:l].decode()


### PR DESCRIPTION
mappy creates a CIGAR string by default (`-c` flag) and so is incompatible with indexes that are created using the `--idx-no-seq` flag.

The previous implementation of mappy did not check for the `MM_I_NO_SEQ` flag and would seg fault when attempting to map a read or retrieve a reference sequence from the index. This patch adds a check to both `mappy.Aligner.seq` and `mappy.Aligner.map` and returns `None` if there is no index sequences. I've chose `None` as this is inline with the behaviour of mappy for reads that do not align/retrieving sequences that aren't in the index, however it might be better to raise an exception so that this error is distinct and can be communicated to the caller.

closes #1007 