### PR TITLE
move MM_VERSION to minimap.h

### DIFF
--- a/main.c
+++ b/main.c
@@ -7,8 +7,6 @@
 #include "mmpriv.h"
 #include "ketopt.h"
 
-#define MM_VERSION "2.24-r1155-dirty"
-
 #ifdef __linux__
 #include <sys/resource.h>
 #include <sys/time.h>

--- a/minimap.h
+++ b/minimap.h
@@ -5,6 +5,8 @@
 #include <stdio.h>
 #include <sys/types.h>
 
+#define MM_VERSION "2.24-r1155-dirty"
+
 #define MM_F_NO_DIAG       0x001 // no exact diagonal hit
 #define MM_F_NO_DUAL       0x002 // skip pairs where query name is lexicographically larger than target name
 #define MM_F_CIGAR         0x004


### PR DESCRIPTION
Move `MM_VERSION` to minimap.h so it can be used by any application _(i.e https://github.com/lh3/minimap2/issues/1030)_ that is linking `libminimap2` and not building `minimap2`.