### PR TITLE
Autodetect aarch64 on POSIX platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ PROG=		minimap2
 PROG_EXTRA=	sdust minimap2-lite
 LIBS=		-lm -lz -lpthread
 
+arch_uname=$(shell uname -m)
+ifeq ($(arch_uname),aarch64)
+      aarch64=1
+else
+      aarch64=
+endif
 ifneq ($(aarch64),)
 	arm_neon=1
 endif


### PR DESCRIPTION
Ensure compiling on aarch64 is seamless by default by autodetecting aarch64 using POSIX standard `uname -m`