### PR TITLE
Add bw_long option to mappy's Aligner class

### DIFF
--- a/python/README.rst
+++ b/python/README.rst
@@ -77,7 +77,9 @@ This constructor accepts the following arguments:
 
 * **min_chain_score**: minimum chaing score
 
-* **bw**: chaining and alignment band width
+* **bw**: chaining and alignment band width (initial chaining and extension)
+
+* **bw_long**: chaining and alignment band width (RMQ-based rechaining and closing gaps)
 
 * **best_n**: max number of alignments to return
 

--- a/python/mappy.pyx
+++ b/python/mappy.pyx
@@ -112,7 +112,7 @@ cdef class Aligner:
 	cdef cmappy.mm_idxopt_t idx_opt
 	cdef cmappy.mm_mapopt_t map_opt
 
-	def __cinit__(self, fn_idx_in=None, preset=None, k=None, w=None, min_cnt=None, min_chain_score=None, min_dp_score=None, bw=None, best_n=None, n_threads=3, fn_idx_out=None, max_frag_len=None, extra_flags=None, seq=None, scoring=None):
+	def __cinit__(self, fn_idx_in=None, preset=None, k=None, w=None, min_cnt=None, min_chain_score=None, min_dp_score=None, bw=None, bw_long=None, best_n=None, n_threads=3, fn_idx_out=None, max_frag_len=None, extra_flags=None, seq=None, scoring=None):
 		self._idx = NULL
 		cmappy.mm_set_opt(NULL, &self.idx_opt, &self.map_opt) # set the default options
 		if preset is not None:
@@ -125,6 +125,7 @@ cdef class Aligner:
 		if min_chain_score is not None: self.map_opt.min_chain_score = min_chain_score
 		if min_dp_score is not None: self.map_opt.min_dp_max = min_dp_score
 		if bw is not None: self.map_opt.bw = bw
+		if bw_long is not None: self.map_opt.bw_long = bw_long
 		if best_n is not None: self.map_opt.best_n = best_n
 		if max_frag_len is not None: self.map_opt.max_frag_len = max_frag_len
 		if extra_flags is not None: self.map_opt.flag |= extra_flags


### PR DESCRIPTION
The Minimap2 behavior was found to handle sequences with large deletions differently when upgraded from v2.17 to v2.26, causing potential issues in projects mapping extensive deletions of ~1200 base pairs. The originally suggested solution of setting `-r 500,500` was observed to be partially non-applicable since the Python Wrapper, `mappy`, only allowed manipulation of parameter `bw`.

In response to issue #1111, where this was originally reported, this commit introduces a modification in the Python wrapper, `mappy`. Until now, `mappy` only allowed manipulation of the `bw` parameter, preventing the suggested fix of setting `-r 500,500`.

This commit introduces a modification in the Python wrapper to include the `bw_long` option in the `Aligner` class. Consequently, both parameters `bw` and `bw_long` can be manipulated, thereby allowing the desired Minimap2 behavior encountered in version 2.17. As a result, this patch ensures consistent handling of sequences containing large deletions irrespective of the version upgrade."

Closes #1111