### PR TITLE
Fix mm_mapopt_t in Mappy

### DIFF
--- a/python/cmappy.pxd
+++ b/python/cmappy.pxd
@@ -36,6 +36,7 @@ cdef extern from "minimap.h":
 		float alt_drop
 
 		int a, b, q, e, q2, e2
+		int transition
 		int sc_ambi
 		int noncan
 		int junc_bonus


### PR DESCRIPTION
Hi!

I have noticed that the `mm_mapopt_t` structure in Mappy's `cmappy.pxd` is missing the recently added variable `transition`. This variable was introduced at #1069. 

Thank you.