### PR TITLE
Throw an exception if the index file can't be opened

### DIFF
--- a/python/mappy.pyx
+++ b/python/mappy.pyx
@@ -2,6 +2,7 @@ from libc.stdint cimport uint8_t, int8_t
 from libc.stdlib cimport free
 cimport cmappy
 import sys
+from cython.cimports.cpython.exc import PyErr_SetFromErrnoWithFilenameObject
 
 __version__ = '2.28'
 
@@ -146,7 +147,9 @@ cdef class Aligner:
 				r = cmappy.mm_idx_reader_open(str.encode(fn_idx_in), &self.idx_opt, NULL)
 			else:
 				r = cmappy.mm_idx_reader_open(str.encode(fn_idx_in), &self.idx_opt, str.encode(fn_idx_out))
-			if r is not NULL:
+			if r is NULL:
+				PyErr_SetFromErrnoWithFilenameObject(OSError, fn_idx_in)
+			else:
 				self._idx = cmappy.mm_idx_reader_read(r, n_threads) # NB: ONLY read the first part
 				cmappy.mm_idx_reader_close(r)
 				cmappy.mm_mapopt_update(&self.map_opt, self._idx)


### PR DESCRIPTION
This has caught me out a few times so I thought I'd make it a PR.

before:
```
>>> import mappy
>>> a = mappy.Aligner("notafile")
>>> a.seq_names
[]
```
no exception is thrown and it's not immediately obvious that the filename is incorrect.

after:
```
>>> import mappy
>>> a = mappy.Aligner("notafile")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "python/mappy.pyx", line 151, in mappy.Aligner.__cinit__
    PyErr_SetFromErrnoWithFilenameObject(OSError, fn_idx_in)
FileNotFoundError: [Errno 2] No such file or directory: 'notafile'
```

It can also throw `PermissionError: [Errno 13] Permission denied: 'unreadablefile'` and so on.