### PR TITLE
Add "tseq" output & make available to Python

### DIFF
--- a/format.c
+++ b/format.c
@@ -338,6 +338,20 @@ int mm_gen_MD(void *km, char **buf, int *max_len, const mm_idx_t *mi, const mm_r
 	return mm_gen_cs_or_MD(km, buf, max_len, mi, r, seq, 1, 0, 0);
 }
 
+int mm_gen_tseq(void *km, char **buf, int *max_len, const mm_idx_t *mi, const mm_reg1_t *r)
+{
+	uint8_t *tseq;
+	kstring_t str;
+	str.s = *buf, str.l = 0, str.m = *max_len;
+	tseq = (uint8_t*)kmalloc(km, r->re - r->rs);
+	int len = mm_idx_getseq(mi, r->rid, r->rs, r->re, tseq);
+	for (int i=0; i<len; i++)
+	    mm_sprintf_lite(&str, "%c", "ACGTN"[tseq[i]]);
+	*max_len = str.m;
+	*buf = str.s;
+	return str.l;
+}
+
 static inline void write_tags(kstring_t *s, const mm_reg1_t *r)
 {
 	int type;

--- a/minimap.h
+++ b/minimap.h
@@ -402,6 +402,7 @@ int mm_map_file_frag(const mm_idx_t *idx, int n_segs, const char **fn, const mm_
  */
 int mm_gen_cs(void *km, char **buf, int *max_len, const mm_idx_t *mi, const mm_reg1_t *r, const char *seq, int no_iden);
 int mm_gen_MD(void *km, char **buf, int *max_len, const mm_idx_t *mi, const mm_reg1_t *r, const char *seq);
+int mm_gen_tseq(void *km, char **buf, int *max_len, const mm_idx_t *mi, const mm_reg1_t *r);
 
 // query sequence name and sequence in the minimap2 index
 int mm_idx_index_name(mm_idx_t *mi);

--- a/python/cmappy.pxd
+++ b/python/cmappy.pxd
@@ -111,6 +111,7 @@ cdef extern from "minimap.h":
 	void *mm_tbuf_get_km(mm_tbuf_t *b)
 	int mm_gen_cs(void *km, char **buf, int *max_len, const mm_idx_t *mi, const mm_reg1_t *r, const char *seq, int no_iden)
 	int mm_gen_MD(void *km, char **buf, int *max_len, const mm_idx_t *mi, const mm_reg1_t *r, const char *seq)
+	int mm_gen_tseq(void *km, char **buf, int *max_len, const mm_idx_t *mi, const mm_reg1_t *r)
 
 #
 # Helper header (because it is hard to expose mm_reg1_t with Cython)

--- a/python/mappy.pyx
+++ b/python/mappy.pyx
@@ -101,7 +101,7 @@ cdef class Alignment:
 			str(self._mlen), str(self._blen), str(self._mapq), tp, ts, "cg:Z:" + self.cigar_str]
 		if self._cs != "": a.append("cs:Z:" + self._cs)
 		if self._MD != "": a.append("MD:Z:" + self._MD)
-		if self._tseq != "": a.append("TS:Z:" + self._tseq)
+		if self._tseq != "": a.append("tq:Z:" + self._tseq)
 		return "\t".join(a)
 
 cdef class ThreadBuffer:


### PR DESCRIPTION
It'd be handy to be able to retrieve the sequence which minimap2 has matched with, to generate HGVS strings or etc.

You could reconstruct this from the long form CS string (see #1194) but it seems like it'd be handy to just retrieve the whole string in one go.

This PR adds an `mm_gen_tseq` C function to retrieve the sequence, and a `tseq` property on the python Alignment object.
 
I've called it "tseq" because it's called that in the write_cs_ds_or_MD function but it's not necessarily a great name.