### PR TITLE
Mention in man page that CIGAR strings in SA tags are approximate

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -2,7 +2,7 @@
 
 Without `-a`, `-c` or `--cs`, minimap2 only finds *approximate* mapping
 locations without detailed base alignment. In particular, the start and end
-positions of the alignment are impricise. With one of those options, minimap2
+positions of the alignment are imprecise. With one of those options, minimap2
 will perform base alignment, which is generally more accurate but is much
 slower.
 

--- a/minimap2.1
+++ b/minimap2.1
@@ -742,7 +742,7 @@ s2	i	Chaining score of the best secondary chain
 NM	i	Total number of mismatches and gaps in the alignment
 MD	Z	To generate the ref sequence in the alignment
 AS	i	DP alignment score
-SA	Z	List of other supplementary alignments
+SA	Z	List of other supplementary alignments (with approximate CIGAR strings)
 ms	i	DP score of the max scoring segment in the alignment
 nn	i	Number of ambiguous bases in the alignment
 ts	A	Transcript strand (splice mode only)


### PR DESCRIPTION
As documented in #724, the CIGAR strings used to describe supplemental alignments in the `SA` tags produced by minimap2 are approximate—for example, a CIGAR string of **`23M 1I 537M 1I 64M 1I 512M 5180H`** for an alignment is turned into **`1136M 3I 5180S`** when this alignment is represented within a SA tag.

This property of SA tags is currently undocumented, both in minimap2's code and in the [SAM optional fields specification](https://github.com/samtools/hts-specs/blob/master/SAMtags.pdf). As far as I can tell, multiple people have been confused by this over the years (#724, #524, #406, #287, https://github.com/eldariont/svim/issues/5).

To rectify this issue, this PR adds a short line to minimap2's man page mentioning that CIGAR strings are approximate. I'd also be happy to add an entry in the FAQ describing this issue, but I think just updating the man page (which is where the README says to check for "detailed description of minimap2 command line options and optional tags") should be sufficient for now.

This PR also fixes an unrelated small typo in the FAQ (`impricise` → `imprecise`).