### PR TITLE
Add `sc_ambi` and `max_chain_skip` parameters to `mappy.pyx`

### DIFF
--- a/python/mappy.pyx
+++ b/python/mappy.pyx
@@ -113,7 +113,7 @@ cdef class Aligner:
 	cdef cmappy.mm_idxopt_t idx_opt
 	cdef cmappy.mm_mapopt_t map_opt
 
-	def __cinit__(self, fn_idx_in=None, preset=None, k=None, w=None, min_cnt=None, min_chain_score=None, min_dp_score=None, bw=None, bw_long=None, best_n=None, n_threads=3, fn_idx_out=None, max_frag_len=None, extra_flags=None, seq=None, scoring=None, sc_ambi=None):
+	def __cinit__(self, fn_idx_in=None, preset=None, k=None, w=None, min_cnt=None, min_chain_score=None, min_dp_score=None, bw=None, bw_long=None, best_n=None, n_threads=3, fn_idx_out=None, max_frag_len=None, extra_flags=None, seq=None, scoring=None, sc_ambi=None, max_chain_skip=None):
 		self._idx = NULL
 		cmappy.mm_set_opt(NULL, &self.idx_opt, &self.map_opt) # set the default options
 		if preset is not None:
@@ -139,6 +139,7 @@ cdef class Aligner:
 				if len(scoring) >= 7:
 					self.map_opt.sc_ambi = scoring[6]
 		if sc_ambi is not None: self.map_opt.sc_ambi = sc_ambi
+		if max_chain_skip is not None: self.map_opt.max_chain_skip |= max_chain_skip
 
 		cdef cmappy.mm_idx_reader_t *r;
 

--- a/python/mappy.pyx
+++ b/python/mappy.pyx
@@ -113,7 +113,7 @@ cdef class Aligner:
 	cdef cmappy.mm_idxopt_t idx_opt
 	cdef cmappy.mm_mapopt_t map_opt
 
-	def __cinit__(self, fn_idx_in=None, preset=None, k=None, w=None, min_cnt=None, min_chain_score=None, min_dp_score=None, bw=None, bw_long=None, best_n=None, n_threads=3, fn_idx_out=None, max_frag_len=None, extra_flags=None, seq=None, scoring=None):
+	def __cinit__(self, fn_idx_in=None, preset=None, k=None, w=None, min_cnt=None, min_chain_score=None, min_dp_score=None, bw=None, bw_long=None, best_n=None, n_threads=3, fn_idx_out=None, max_frag_len=None, extra_flags=None, seq=None, scoring=None, sc_ambi=None):
 		self._idx = NULL
 		cmappy.mm_set_opt(NULL, &self.idx_opt, &self.map_opt) # set the default options
 		if preset is not None:
@@ -138,6 +138,7 @@ cdef class Aligner:
 				self.map_opt.q2, self.map_opt.e2 = scoring[4], scoring[5]
 				if len(scoring) >= 7:
 					self.map_opt.sc_ambi = scoring[6]
+		if sc_ambi is not None: self.map_opt.sc_ambi = sc_ambi
 
 		cdef cmappy.mm_idx_reader_t *r;
 

--- a/python/mappy.pyx
+++ b/python/mappy.pyx
@@ -139,7 +139,7 @@ cdef class Aligner:
 				if len(scoring) >= 7:
 					self.map_opt.sc_ambi = scoring[6]
 		if sc_ambi is not None: self.map_opt.sc_ambi = sc_ambi
-		if max_chain_skip is not None: self.map_opt.max_chain_skip |= max_chain_skip
+		if max_chain_skip is not None: self.map_opt.max_chain_skip = max_chain_skip
 
 		cdef cmappy.mm_idx_reader_t *r;
 


### PR DESCRIPTION
Hi Heng,
as discussed at IGGSy, this PR exposes the `sc_ambi` and `max_gaplen` parameters already exposed on the CLI interface in the cython/mappy interface as well.
Same as other options in the mappy interface, they're set after initializing the preset and can overwrite it.
We're using this to align sequences in which we've inserted spacers that we do not want to align – not sure how common that use case is, but other people might also want to set these parameters for other reasons.
Best,
Leon