### PR TITLE
`paftools sam2paf`: Fix edge case for an empty trailing line in sam file

### DIFF
--- a/misc/paftools.js
+++ b/misc/paftools.js
@@ -1765,6 +1765,7 @@ function paf_sam2paf(args)
 	while (file.readline(buf) >= 0) {
 		var m, n_cigar = 0, line = buf.toString();
 		++lineno;
+		if (line.length == 0) continue; // fix edge case of trailing lines
 		if (line.charAt(0) == '@') {
 			if (/^@SQ/.test(line)) {
 				var name = (m = /\tSN:(\S+)/.exec(line)) != null? m[1] : null;


### PR DESCRIPTION
Handle edge case for trailing lines in input.

It happens when I try to run `paftools.js sam2paf XX.sam`, and the sam file contains an empty line at the end of the file. Because sometimes sam files are generated by different programs, some programs might leave a trailing line like a normal txt file. This small fix makes paftools more robust.