### PR TITLE
Fix python segfault when using an invalid Aligner

### DIFF
--- a/python/mappy.pyx
+++ b/python/mappy.pyx
@@ -1,7 +1,6 @@
 from libc.stdint cimport uint8_t, int8_t
 from libc.stdlib cimport free
 cimport cmappy
-import sys
 
 __version__ = '2.30'
 


### PR DESCRIPTION
Similar to #1195, we recently saw python segfault due to malformed paths.

Simple repro case in the REPL is:
```
>>> from mappy import Aligner
>>> aligner = Aligner("bad")
>>> aligner.
Segmentation fault (core dumped)
```
where the segfault occurred on line 3 when pressing tab after the `.` to display attributes of the object. The same crash occurs if trying to access the fields with missing `NULL` checks, ie `aligner.n_seq`.

Note that #1195 is probably a better fix if a behaviour change is allowed and would avoid the need for any `NULL` checks.

See commit descriptions for more details.