### PR TITLE
Fix use-after-free in mappy

### DIFF
--- a/python/mappy.pyx
+++ b/python/mappy.pyx
@@ -189,7 +189,6 @@ cdef class Aligner:
 		if self._idx is NULL: return None
 		if buf is None: b = ThreadBuffer()
 		else: b = buf
-		km = cmappy.mm_tbuf_get_km(b._b)
 
 		_seq = seq if isinstance(seq, bytes) else seq.encode()
 		if name is not None:
@@ -216,6 +215,7 @@ cdef class Aligner:
 					c = h.cigar32[k]
 					cigar.append([c>>4, c&0xf])
 				if cs or ds or MD: # generate the cs/ds and/or the MD tag, if requested
+					km = cmappy.mm_tbuf_get_km(b._b)
 					_cur_seq = _seq2 if h.seg_id > 0 and seq2 is not None else _seq
 					if cs:
 						l_cs_str = cmappy.mm_gen_cs(km, &cs_str, &m_cs_str, self._idx, &regs[i], _cur_seq, 1)


### PR DESCRIPTION
`cmappy.mm_map_aux()` takes in `b._b` which can end up reallocating `km` at the end of `mm_map_frag_core()`:

https://github.com/lh3/minimap2/blob/e2542e6425a40adaa710e07ae5e6188c91f8728c/python/mappy.pyx#L192-L208

https://github.com/lh3/minimap2/blob/e2542e6425a40adaa710e07ae5e6188c91f8728c/map.c#L374-L375

Since the address of `km` is cached before those calls it ends up pointing to freed memory.

This can result in a crash as seen in #1183, however it also happens to Just Work most of the time since the new allocation often lands at the same address as the old one. Preloading ASAN or a similar replacement allocator that doesn't have that behaviour results in a reliable crash:
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==6003==ERROR: AddressSanitizer: SEGV on unknown address 0x7cc7aa102810 (pc 0x7cca265cba44 bp 0x0000000002c9 sp 0x7ffca6624630 T0)
==6003==The signal is caused by a READ memory access.
    #0 0x7cca265cba44 in kmalloc minimap2/kalloc.c:141
    #1 0x7cca265c115e in write_cs_ds_or_MD minimap2/format.c:340
    #2 0x7cca265c26aa in write_cs_ds_or_MD minimap2/format.c:339
    #3 0x7cca265c26aa in mm_gen_cs_ds_or_MD minimap2/format.c:371
    #4 0x7cca265c270d in mm_gen_cs_or_MD minimap2/format.c:379
    #5 0x7cca265c2772 in mm_gen_MD minimap2/format.c:394
    #6 0x7cca265ee5b8 in __pyx_gb_5mappy_7Aligner_8generator python/mappy.c:7758
    #7 0x7cca265ddfa8 in __Pyx_Coroutine_SendEx python/mappy.c:19463
    #8 0x7cca265e199b in __Pyx_Generator_Next python/mappy.c:19729
```

Moving the caching until when it's needed fixes the crash.

Fixes #1183