### PR TITLE
Add optional jemalloc support via make jemalloc=1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,22 @@ jobs:
         make CC=${{ matrix.compiler }}
         file minimap2 | grep x86-64
 
+  build-linux-jemalloc:
+    name: Linux x86_64 (jemalloc)
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout minimap2
+      uses: actions/checkout@v4
+
+    - name: Install jemalloc
+      run: sudo apt-get update && sudo apt-get install -y libjemalloc-dev
+
+    - name: Compile with jemalloc
+      run: |
+        make jemalloc=1
+        ./minimap2 --version | grep +jemalloc
+
   build-linux-aarch64:
     name: Linux aarch64
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,11 @@ ifneq ($(tsan),)
 	LIBS+=-fsanitize=thread -ldl
 endif
 
+ifneq ($(jemalloc),)
+	CPPFLAGS+=-DUSE_JEMALLOC
+	LIBS+=-ljemalloc
+endif
+
 .PHONY:all extra clean depend
 .SUFFIXES:.c .o
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ implementation to the different SIMD instruction sets. To compile using SIMDe,
 use `make -f Makefile.simde`. To compile for ARM CPUs, use `Makefile.simde`
 with the ARM related command lines given above.
 
+Minimap2 optionally supports [jemalloc][jemalloc] for improved memory
+management. This can reduce heap fragmentation and peak memory usage when
+loading and destroying many indexes. To compile with jemalloc, install
+libjemalloc-dev (or equivalent) and type `make jemalloc=1`. The `--version`
+output will show `+jemalloc` when built with this option.
+
 ### <a name="general"></a>General usage
 
 Without any options, minimap2 takes a reference database and a query sequence
@@ -426,4 +432,5 @@ mappy` or [from BioConda][mappyconda] via `conda install -c bioconda mappy`.
 [doi]: https://doi.org/10.1093/bioinformatics/bty191
 [doi2]: https://doi.org/10.1093/bioinformatics/btab705
 [simde]: https://github.com/nemequ/simde
+[jemalloc]: https://github.com/jemalloc/jemalloc
 [unimap]: https://github.com/lh3/unimap

--- a/minimap.h
+++ b/minimap.h
@@ -5,7 +5,13 @@
 #include <stdio.h>
 #include <sys/types.h>
 
-#define MM_VERSION "2.30-r1290-dirty"
+#ifdef USE_JEMALLOC
+#define MM_ALLOC_TAG "+jemalloc"
+#else
+#define MM_ALLOC_TAG ""
+#endif
+
+#define MM_VERSION "2.30-r1290-dirty" MM_ALLOC_TAG
 
 #define MM_F_NO_DIAG       (0x001LL) // no exact diagonal hit
 #define MM_F_NO_DUAL       (0x002LL) // skip pairs where query name is lexicographically larger than target name


### PR DESCRIPTION
Thank you for the ongoing development of minimap2. I'm especially grateful for the consideration with the permissive licensing, and a viable C API to interact with.

I'm currently building out a [DuckDB](https://duckdb.org/) extension called [MIINT](https://duckdb.org/community_extensions/extensions/miint) which brings columnar analytics and SQL-driven processing to the microbiome space. Some of the methods, such as read_fastx are applicable beyond the microbiome.

In expanding capability, we embedded minimap2 based on the wonderful Python C API example. On top of this, we developed a database sharding approach expressed through a DuckDB table function called `align_minimap2_sharded`. The specific need is to align PacBio Revio reads against hundreds of thousands of diverse microbial genomes. In our testing, we observed unexpected and unexplained memory growth through runtime. Examination suggested memory fragmentation arising from a large number of small malloc/free operations within minimap2, which were magnified in our use loading and unloading a large number of indices. 

To address this, we are proposing allowing optional compile time support of [jemalloc](https://jemalloc.net) which is better suited for the threaded memory allocation pattern we are using. `LD_PRELOAD` of jemalloc showed a considerable drop of peak RSS without a noticed effect on performance. While injection with `LD_PRELOAD` works, it's not an ideal solution as it affects the entirety of runtime and requires users to remember to set it. 

This pull request allows the use of jemalloc, which replaces `malloc`, `free`, etc. No code changes surrounding memory allocation are necessary. 

To be transparent, this work was done in close hand with @claude. 