### PR TITLE
Update mappy.pyx

### DIFF
--- a/python/mappy.pyx
+++ b/python/mappy.pyx
@@ -116,7 +116,7 @@ cdef class ThreadBuffer:
 cdef class Aligner:
 	cdef cmappy.mm_idx_t *_idx
 	cdef cmappy.mm_idxopt_t idx_opt
-	cdef cmappy.mm_mapopt_t map_opt
+	cdef public cmappy.mm_mapopt_t map_opt
 
 	def __cinit__(self, fn_idx_in=None, preset=None, k=None, w=None, min_cnt=None, min_chain_score=None, min_dp_score=None, bw=None, bw_long=None, best_n=None, n_threads=3, fn_idx_out=None, max_frag_len=None, extra_flags=None, seq=None, scoring=None, sc_ambi=None, max_chain_skip=None):
 		self._idx = NULL


### PR DESCRIPTION
Make map_opt attributes public to python API; currently the mappy API seems unable to replicate some of the commandline behaviors. In particular, I'm interested in modifying the -p min secondary-to-primary score ratio value and cannot seem to do so through mappy. I believe this minimal edit will enable setting the attribute directly.