### PR TITLE
Update uses of ts tag to standard-defined TS tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ full-length cDNA, EST, PacBio Iso-seq, Nanopore 2D cDNA-seq and Direct RNA-seq.
 They produce data of varying quality and properties. By default, `-x splice`
 assumes the read orientation relative to the transcript strand is unknown. It
 tries two rounds of alignment to infer the orientation and write the strand to
-the `ts` SAM/PAF tag if possible. For Iso-seq, Direct RNA-seq and tranditional
+the `TS` SAM/PAF tag if possible. For Iso-seq, Direct RNA-seq and tranditional
 full-length cDNAs, it would be desired to apply `-u f` to force minimap2 to
 consider the forward transcript strand only. This speeds up alignment with
 slight improvement to accuracy. For noisy Nanopore Direct RNA-seq reads, it is

--- a/cookbook.md
+++ b/cookbook.md
@@ -115,8 +115,8 @@ This is because minimap2 models one additional evolutionarily conserved base
 around a canonical junction, but SIRV doesn't honor this signal. Option
 `--splice-flank=no` asks minimap2 no to model this additional base.
 
-In the output a tag `ts:A:+` indicates that the read strand is the same as the
-transcript strand; `ts:A:-` indicates the read strand is opposite to the
+In the output a tag `TS:A:+` indicates that the read strand is the same as the
+transcript strand; `TS:A:-` indicates the read strand is opposite to the
 transcript strand. This tag is inferred from the GT-AG signal and is thus only
 available to spliced reads.
 

--- a/format.c
+++ b/format.c
@@ -402,7 +402,7 @@ static inline void write_tags(kstring_t *s, const mm_reg1_t *r)
 	if (r->p) {
 		mm_sprintf_lite(s, "\tNM:i:%d\tms:i:%d\tAS:i:%d\tnn:i:%d", r->blen - r->mlen + r->p->n_ambi, r->p->dp_max0, r->p->dp_score, r->p->n_ambi);
 		if (r->p->trans_strand == 1 || r->p->trans_strand == 2)
-			mm_sprintf_lite(s, "\tts:A:%c", "?+-?"[r->p->trans_strand]);
+			mm_sprintf_lite(s, "\tTS:A:%c", "?+-?"[r->p->trans_strand]);
 	}
 	mm_sprintf_lite(s, "\ttp:A:%c\tcm:i:%d\ts1:i:%d", type, r->cnt, r->score);
 	if (r->parent == r->id) mm_sprintf_lite(s, "\ts2:i:%d", r->subsc);

--- a/minimap2.1
+++ b/minimap2.1
@@ -800,7 +800,7 @@ AS	i	DP alignment score
 SA	Z	List of other supplementary alignments (with approximate CIGAR strings)
 ms	i	DP score of the max scoring segment in the alignment
 nn	i	Number of ambiguous bases in the alignment
-ts	A	Transcript strand (splice mode only)
+TS	A	Transcript strand (splice mode only)
 cg	Z	CIGAR string (only in PAF)
 cs	Z	Difference string
 dv	f	Approximate per-base sequence divergence

--- a/python/mappy.pyx
+++ b/python/mappy.pyx
@@ -94,9 +94,9 @@ cdef class Alignment:
 		else: strand = '?'
 		if self._is_primary != 0: tp = 'tp:A:P'
 		else: tp = 'tp:A:S'
-		if self._trans_strand > 0: ts = 'ts:A:+'
-		elif self._trans_strand < 0: ts = 'ts:A:-'
-		else: ts = 'ts:A:.'
+		if self._trans_strand > 0: ts = 'TS:A:+'
+		elif self._trans_strand < 0: ts = 'TS:A:-'
+		else: ts = 'TS:A:.'
 		a = [str(self._q_st), str(self._q_en), strand, self._ctg, str(self._ctg_len), str(self._r_st), str(self._r_en),
 			str(self._mlen), str(self._blen), str(self._mapq), tp, ts, "cg:Z:" + self.cigar_str]
 		if self._cs != "": a.append("cs:Z:" + self._cs)


### PR DESCRIPTION
The `TS:A` tag for transcript strand mapping has been available in the SAM tags specification since March 2020. This PR updates all uses of the user-defined `ts:A` tag to `TS:A` to match the specification.