### PR TITLE
Avoid invalid RMQ iterator pointer state

### DIFF
--- a/krmq.h
+++ b/krmq.h
@@ -342,19 +342,20 @@ int main(void) {
 
 #define __KRMQ_ITR(suf, __scope, __type, __head, __cmp) \
 	struct krmq_itr_##suf { \
-		const __type *stack[KRMQ_MAX_DEPTH], **top; \
+		const __type *stack[KRMQ_MAX_DEPTH]; \
+		unsigned depth; \
 	}; \
 	__scope void krmq_itr_first_##suf(const __type *root, struct krmq_itr_##suf *itr) { \
 		const __type *p; \
-		for (itr->top = itr->stack - 1, p = root; p; p = p->__head.p[0]) \
-			*++itr->top = p; \
+		for (itr->depth = 0, p = root; p; p = p->__head.p[0]) \
+			itr->stack[itr->depth++] = p; \
 	} \
 	__scope int krmq_itr_find_##suf(const __type *root, const __type *x, struct krmq_itr_##suf *itr) { \
 		const __type *p = root; \
-		itr->top = itr->stack - 1; \
+		itr->depth = 0; \
 		while (p != 0) { \
 			int cmp; \
-			*++itr->top = p; \
+			itr->stack[itr->depth++] = p; \
 			cmp = __cmp(x, p); \
 			if (cmp < 0) p = p->__head.p[0]; \
 			else if (cmp > 0) p = p->__head.p[1]; \
@@ -364,18 +365,18 @@ int main(void) {
 	} \
 	__scope int krmq_itr_next_bidir_##suf(struct krmq_itr_##suf *itr, int dir) { \
 		const __type *p; \
-		if (itr->top < itr->stack) return 0; \
+		if (itr->depth == 0) return 0; \
 		dir = !!dir; \
-		p = (*itr->top)->__head.p[dir]; \
+		p = itr->stack[itr->depth - 1]->__head.p[dir]; \
 		if (p) { /* go down */ \
 			for (; p; p = p->__head.p[!dir]) \
-				*++itr->top = p; \
+				itr->stack[itr->depth++] = p; \
 			return 1; \
 		} else { /* go up */ \
 			do { \
-				p = *itr->top--; \
-			} while (itr->top >= itr->stack && p == (*itr->top)->__head.p[dir]); \
-			return itr->top < itr->stack? 0 : 1; \
+				p = itr->stack[--itr->depth]; \
+			} while (itr->depth > 0 && p == itr->stack[itr->depth - 1]->__head.p[dir]); \
+			return itr->depth > 0? 1 : 0; \
 		} \
 	} \
 
@@ -458,7 +459,7 @@ int main(void) {
  *
  * @return pointer if present; NULL otherwise
  */
-#define krmq_at(itr) ((itr)->top < (itr)->stack? 0 : *(itr)->top)
+#define krmq_at(itr) ((itr)->depth == 0? 0 : (itr)->stack[(itr)->depth - 1])
 
 #define KRMQ_INIT2(suf, __scope, __type, __head, __cmp, __lt2) \
 	__KRMQ_FIND(suf, __scope, __type, __head,  __cmp) \


### PR DESCRIPTION
The RMQ iterator formed a pointer one element before its stack object, causing undefined behavior in C.

This replaces the RMQ iterator's before-array pointer sentinel with an in-bounds stack depth index in `krmq.h`.

#### Reproducer

`mm_map_frag_core` in `map.c` reaches `mg_lchain_rmq` in `lchain.c` which traverses the RMQ iterator. GCC diagnoses the one-before-array pointer while compiling `lchain.c`. This is a compile-time undefined-behavior check, not a crash reproducer.

Run from the repository root:
```sh
gcc -std=c11 -O3 -DHAVE_KALLOC -Wall -Warray-bounds=2 -Werror=array-bounds -I. -c lchain.c -o /tmp/minimap2-rmq-lchain.o
```

Expected result: The baseline commit fails with GCC's `-Warray-bounds` diagnostic. The candidate commit exits successfully.
